### PR TITLE
Emit the error if the ITLibrary cannot be created

### DIFF
--- a/Sources/itunes_json/main.swift
+++ b/Sources/itunes_json/main.swift
@@ -211,8 +211,16 @@ func save(jsonData : Data) throws {
     }
 }
 
-guard let itunes = try? ITLibrary(apiVersion: "1.0") else {
-    print("Cannot open the library")
+let itunesLib: ITLibrary?
+do {
+    itunesLib = try ITLibrary(apiVersion: "1.0")
+} catch {
+    print("Cannot open the library: \(error).")
+    exit(1)
+}
+
+guard let itunes = itunesLib else {
+    print("No library")
     exit(1)
 }
 


### PR DESCRIPTION
When I run a release build from github locally, the library fails to open. Log the error.