### PR TITLE
Do not allow album titles to be empty strings

### DIFF
--- a/Sources/itunes_json/main.swift
+++ b/Sources/itunes_json/main.swift
@@ -8,7 +8,7 @@ extension Track {
         let artist = mediaItem.artist
         let album = mediaItem.album
 
-        if let name = album.title {
+        if let name = album.title, name.count > 0 {
             self.album = name
         }
         if let name = album.albumArtist {


### PR DESCRIPTION
This seems to be a new thing in macos 10.15 that did not happen in 10.14. See https://github.com/bolsinga/web_generator/pull/40