### PR TITLE
Revert "log to stderr if a mediaitem has a non-existant file URL (#11)"

### DIFF
--- a/Sources/itunes_json/Track+MediaItem.swift
+++ b/Sources/itunes_json/Track+MediaItem.swift
@@ -78,9 +78,6 @@ extension Track {
             self.kind = kind
         }
         if let location = mediaItem.location {
-            if location.isFileURL && !FileManager.default.fileExists(atPath: location.path) {
-                print("Non-existant media file: \(location)", to: &standardError)
-            }
             self.location = location.absoluteString
         }
         if mediaItem.mediaKind == .kindMovie {


### PR DESCRIPTION
This reverts commit 0f8f329dd97450d851afc0b241d148c1937ef6c7.

Basically this never happens and takes awhile to process.