### PR TITLE
Manually parse arguments to prepare for stdin

### DIFF
--- a/Sources/tool/Program.swift
+++ b/Sources/tool/Program.swift
@@ -5,7 +5,6 @@ import iTunes
 extension Source: EnumerableFlag {}
 extension Destination: EnumerableFlag {}
 
-@main
 struct Program: AsyncParsableCommand {
 
   @Argument(

--- a/Sources/tool/main.swift
+++ b/Sources/tool/main.swift
@@ -1,0 +1,15 @@
+//
+//  main.swift
+//
+//
+//  Created by Greg Bolsinga on 12/11/23.
+//
+
+import Foundation
+
+let command = Program.parseOrExit()
+do {
+    try await command.run()
+} catch {
+  Program.exit(withError: error)
+}


### PR DESCRIPTION
- main.swift is a special file that just "runs code top to bottom". -- Use this in a future diff to read from stdin
- Program struct is no longer annotated with @main since main.swift will now do the work.
- See https://swiftpackageindex.com/apple/swift-argument-parser/1.3.0/documentation/argumentparser/manualparsing for more.