### PR TITLE
Add Source.jsonString to gather data from a jsonString

### DIFF
--- a/Sources/iTunes/Source+Tracks.swift
+++ b/Sources/iTunes/Source+Tracks.swift
@@ -8,12 +8,14 @@
 import Foundation
 
 extension Source {
-  public func gather() async throws -> [Track] {
+  public func gather(_ source: String?) async throws -> [Track] {
     switch self {
     case .itunes:
       return try Track.gatherAllTracks()
     case .musickit:
       return try await Track.gatherWithMusicKit()
+    case .jsonString:
+      return try Track.createFromString(source)
     }
   }
 }

--- a/Sources/iTunes/Source.swift
+++ b/Sources/iTunes/Source.swift
@@ -10,4 +10,5 @@ import Foundation
 public enum Source: CaseIterable {
   case itunes
   case musickit
+  case jsonString
 }

--- a/Sources/iTunes/Track+String.swift
+++ b/Sources/iTunes/Track+String.swift
@@ -1,0 +1,23 @@
+//
+//  Track+String.swift
+//
+//
+//  Created by Greg Bolsinga on 12/11/23.
+//
+
+import Foundation
+
+enum JSONDecodingError: Error {
+  case stringEncodingError
+}
+
+extension Track {
+  static public func createFromString(_ source: String?) throws -> [Track] {
+    guard let source else { preconditionFailure("Should have been caught during ParsableArguments.validate().") }
+    guard let data = source.data(using: .utf8) else { throw JSONDecodingError.stringEncodingError }
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try decoder.decode([Track].self, from: data)
+  }
+}

--- a/Sources/tool/Program.swift
+++ b/Sources/tool/Program.swift
@@ -30,8 +30,21 @@ struct Program: AsyncParsableCommand {
   @Flag var source: Source = .itunes
   @Flag var destination: Destination = .json
 
+  @Argument(help: "Optional json string to parse when --json-string is passed as input.")
+  var jsonSource: String?
+
+  mutating func validate() throws {
+    if jsonSource != nil, source != .jsonString {
+      throw ValidationError("Passing JSON Source requires --json-string to be passed.")
+    }
+
+    if jsonSource == nil, source == .jsonString {
+      throw ValidationError("Using --json-string requires JSON String to be passed as an argument.")
+    }
+  }
+
   func run() async throws {
-    let tracks = try await source.gather()
+    let tracks = try await source.gather(jsonSource)
 
     let data = try tracks.data(for: destination)
 


### PR DESCRIPTION
- The JSON string is passed fully on the command line.
- This sets the program up to be able to read json from stdin.
- The following is the string tested from the Xcode arguments list:

'[{"album":"RainOnLens","artist":"(Smog)","bitRate":192,"dateAdded":"2003-12-15T18:02:55Z","dateModified":"2007-03-07T05:31:20Z","genre":"Alternative","kind":"MPEGaudiofile","location":"weee","name":"DirtyPants","persistentID":17859820717873205096,"playCount":25,"playDateUTC":"2023-04-13T01:21:29Z","sampleRate":44100,"size":6519822,"totalTime":271568,"trackCount":10,"trackNumber":5,"trackType":"File","year":2001}]'