### PR TITLE
Do not emit "internet audio stream"

### DIFF
--- a/Sources/iTunes/SQLSourceEncoder.swift
+++ b/Sources/iTunes/SQLSourceEncoder.swift
@@ -19,6 +19,7 @@ extension Track {
     guard !kind.contains("video") else { return false }
     guard !kind.contains("pdf") else { return false }
     guard !kind.contains("itunes lp") else { return false }
+    guard !kind.contains("internet audio stream") else { return false }
     return true
   }
 
@@ -92,7 +93,7 @@ extension Track {
   }
 
   var kindSelect: String {
-    guard let kind else { preconditionFailure() }
+    guard let kind else { preconditionFailure("\(self)") }
     return "SELECT id FROM kinds WHERE name = '\(kind)'"
   }
 


### PR DESCRIPTION
- Old iTunes XML files had this "kind". These tracks do not have the additional data used today, and they are not found in the output today either. Just ignore them.
- Dump the Track information for debugging help when it does not have a "kind".