### PR TITLE
Do not encode "old" podcasts.

### DIFF
--- a/Sources/iTunes/SQLSourceEncoder.swift
+++ b/Sources/iTunes/SQLSourceEncoder.swift
@@ -14,7 +14,12 @@ extension String {
 }
 
 extension Track {
+  fileprivate var oldPodcastWithoutKind: Bool {
+    kind == nil && (podcast != nil && podcast!)
+  }
+
   fileprivate var shouldEncode: Bool {
+    guard !oldPodcastWithoutKind else { return false }
     let kind: String = kind?.lowercased() ?? ""
     guard !kind.contains("video") else { return false }
     guard !kind.contains("pdf") else { return false }


### PR DESCRIPTION
These seem to be kind==nil and podcast=true files.

Example:

[{   "artist": "Tom Scharpling and WFMU",   "trackType": "URL",   "releaseDate": "2012-02-20T17:50:43Z",   "album": "Best Show Gems with Tom Scharpling | WFMU",   "totalTime": "684000",   "dateAdded": "2014-05-16T04:43:57Z",   "persistentID": "5856690655899505700",   "playCount": "1",   "size": "10965768",   "podcast": "true",   "genre": "Podcast",   "name": "Special Marathon Week 1 Podcast from Feb 20, 2012",   "location": "http://podcast.wfmu.org/BD/bd120220p.mp3" }]