### PR TITLE
When there is no album name, fallback to the song name

### DIFF
--- a/Sources/iTunes/SQLSourceEncoder.swift
+++ b/Sources/iTunes/SQLSourceEncoder.swift
@@ -33,7 +33,7 @@ extension Track {
   }
 
   var albumName: String {
-    (album ?? "").quoteEscaped
+    (album ?? name).quoteEscaped
   }
 
   var albumTrackCount: Int {


### PR DESCRIPTION
- This only applies to older data sets. 
-- This is a workaround for now, as it may be necessary to be smarter about doing this across all the data sets...