### PR TITLE
Add QuoteEscaped property wrapper

### DIFF
--- a/Sources/iTunes/QuoteEscaped.swift
+++ b/Sources/iTunes/QuoteEscaped.swift
@@ -1,0 +1,17 @@
+//
+//  QuoteEscaped.swift
+//
+//
+//  Created by Greg Bolsinga on 12/30/23.
+//
+
+import Foundation
+
+@propertyWrapper
+struct QuoteEscaped: Hashable {
+  var wrappedValue: String
+
+  var projectedValue: String {
+    wrappedValue.replacingOccurrences(of: "'", with: "''")
+  }
+}

--- a/Sources/iTunes/RowArtist.swift
+++ b/Sources/iTunes/RowArtist.swift
@@ -19,6 +19,6 @@ struct RowArtist: SQLRow {
   }
 
   var insertStatement: String {
-    "INSERT INTO artists (name, sortname) VALUES ('\(name.name)', '\(name.sorted)');"
+    "INSERT INTO artists (name, sortname) VALUES ('\(name.$name)', '\(name.$sorted)');"
   }
 }

--- a/Sources/iTunes/RowKind.swift
+++ b/Sources/iTunes/RowKind.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 struct RowKind: SQLRow {
-  private let kind: String
+  @QuoteEscaped private var kind: String
 
   init(_ kind: String) {
     self.kind = kind
   }
 
   var insertStatement: String {
-    "INSERT INTO kinds (name) VALUES ('\(kind.quoteEscaped)');"
+    "INSERT INTO kinds (name) VALUES ('\($kind)');"
   }
 }

--- a/Sources/iTunes/RowSong.swift
+++ b/Sources/iTunes/RowSong.swift
@@ -10,7 +10,7 @@ import Foundation
 struct RowSong: SQLRow {
   private let name: SortableName
   private let itunesid: UInt
-  private let composer: String
+  @QuoteEscaped private var composer: String
   private let trackNumber: Int
   private let year: Int
   private let size: UInt64
@@ -18,7 +18,7 @@ struct RowSong: SQLRow {
   private let dateAdded: String
   private let dateReleased: String
   private let dateModified: String
-  private let comments: String
+  @QuoteEscaped private var comments: String
   private let artistSelect: String
   private let albumSelect: String
   private let kindSelect: String
@@ -26,7 +26,7 @@ struct RowSong: SQLRow {
   init(_ track: Track) {
     self.name = track.songName
     self.itunesid = track.persistentID
-    self.composer = (track.composer ?? "").quoteEscaped
+    self.composer = track.composer ?? ""
     self.trackNumber = track.songTrackNumber
     self.year = track.songYear
     self.size = track.songSize
@@ -34,13 +34,13 @@ struct RowSong: SQLRow {
     self.dateAdded = track.dateAddedISO8601
     self.dateReleased = track.dateReleasedISO8601
     self.dateModified = track.dateModifiedISO8601
-    self.comments = (track.comments ?? "").quoteEscaped
+    self.comments = track.comments ?? ""
     self.artistSelect = track.artistSelect
     self.albumSelect = track.albumSelect
     self.kindSelect = track.kindSelect
   }
 
   var insertStatement: String {
-    "INSERT INTO songs (name, sortname, itunesid, artistid, albumid, kindid, composer, tracknumber, year, size, duration, dateadded, datereleased, datemodified, comments) VALUES ('\(name.name)', '\(name.sorted)', '\(itunesid)', (\(artistSelect)), (\(albumSelect)), (\(kindSelect)), '\(composer)', \(trackNumber), \(year), \(size), \(duration), '\(dateAdded)', '\(dateReleased)', '\(dateModified)', '\(comments)');"
+    "INSERT INTO songs (name, sortname, itunesid, artistid, albumid, kindid, composer, tracknumber, year, size, duration, dateadded, datereleased, datemodified, comments) VALUES ('\(name.$name)', '\(name.$sorted)', '\(itunesid)', (\(artistSelect)), (\(albumSelect)), (\(kindSelect)), '\($composer)', \(trackNumber), \(year), \(size), \(duration), '\(dateAdded)', '\(dateReleased)', '\(dateModified)', '\($comments)');"
   }
 }

--- a/Sources/iTunes/SQLSourceEncoder.swift
+++ b/Sources/iTunes/SQLSourceEncoder.swift
@@ -18,12 +18,6 @@ extension Logger {
   static let duplicateArtist = Logger(subsystem: "sql", category: "duplicateArtist")
 }
 
-extension String {
-  var quoteEscaped: String {
-    self.replacingOccurrences(of: "'", with: "''")
-  }
-}
-
 extension Track {
   fileprivate var debugLogInformation: String {
     "album: \(String(describing: album)), artist: \(String(describing: artist)), kind: \(String(describing: kind)), name: \(name), podcast: \(String(describing: podcast)), trackCount: \(String(describing: trackCount)), trackNumber: \(String(describing: trackNumber)), year: \(String(describing: year))"
@@ -34,8 +28,7 @@ extension Track {
       Logger.noArtist.error("\(debugLogInformation, privacy: .public)")
       return SortableName()
     }
-    return SortableName(
-      name: name.quoteEscaped, sorted: (sortArtist ?? sortAlbumArtist)?.quoteEscaped ?? "")
+    return SortableName(name: name, sorted: (sortArtist ?? sortAlbumArtist) ?? "")
   }
 
   var albumName: SortableName {
@@ -43,7 +36,7 @@ extension Track {
       Logger.noAlbum.error("\(debugLogInformation, privacy: .public)")
       return SortableName()
     }
-    return SortableName(name: album.quoteEscaped, sorted: sortAlbum?.quoteEscaped ?? "")
+    return SortableName(name: album, sorted: sortAlbum ?? "")
   }
 
   var albumTrackCount: Int {
@@ -118,7 +111,7 @@ extension Track {
   }
 
   var songName: SortableName {
-    SortableName(name: name.quoteEscaped, sorted: sortName?.quoteEscaped ?? "")
+    SortableName(name: name, sorted: sortName ?? "")
   }
 
   var songPlayCount: Int {

--- a/Sources/iTunes/SortableName.swift
+++ b/Sources/iTunes/SortableName.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct SortableName: Hashable {
-  let name: String
-  let sorted: String
+  @QuoteEscaped var name: String
+  @QuoteEscaped var sorted: String
 
   init(name: String = "", sorted: String = "") {
     self.name = name


### PR DESCRIPTION
- projectedValue is quote escaped for SQL
- This way quoteEscaped strings are only created when needed, preventing a possible bug of double-escaping strings.