### PR TITLE
explicitly adopt safeQuoted instead of a default for all strings

### DIFF
--- a/Sources/iTunes/RowAlbum.swift
+++ b/Sources/iTunes/RowAlbum.swift
@@ -17,12 +17,12 @@ struct RowAlbum: SQLRow {
 
 extension RowAlbum: SQLSelectID {
   var selectID: String {
-    "(SELECT id FROM albums WHERE name = \(name.name, sql:.quoted) AND trackcount = \(trackCount) AND disccount = \(discCount) AND discnumber = \(discNumber) AND compilation = \(compilation))"
+    "(SELECT id FROM albums WHERE name = \(name.name, sql:.safeQuoted) AND trackcount = \(trackCount) AND disccount = \(discCount) AND discnumber = \(discNumber) AND compilation = \(compilation))"
   }
 }
 
 extension RowAlbum: SQLInsert {
   var insert: String {
-    "INSERT INTO albums (name, sortname, trackcount, disccount, discnumber, compilation) VALUES (\(name.name, sql:.quoted), \(name.sorted, sql:.quoted), \(trackCount), \(discCount), \(discNumber), \(compilation));"
+    "INSERT INTO albums (name, sortname, trackcount, disccount, discnumber, compilation) VALUES (\(name.name, sql:.safeQuoted), \(name.sorted, sql:.safeQuoted), \(trackCount), \(discCount), \(discNumber), \(compilation));"
   }
 }

--- a/Sources/iTunes/RowArtist.swift
+++ b/Sources/iTunes/RowArtist.swift
@@ -17,12 +17,12 @@ struct RowArtist: SQLRow {
 
 extension RowArtist: SQLSelectID {
   var selectID: String {
-    "(SELECT id FROM artists WHERE name = \(name.name, sql:.quoted))"
+    "(SELECT id FROM artists WHERE name = \(name.name, sql:.safeQuoted))"
   }
 }
 
 extension RowArtist: SQLInsert {
   var insert: String {
-    "INSERT INTO artists (name, sortname) VALUES (\(name.name, sql:.quoted), \(name.sorted, sql:.quoted));"
+    "INSERT INTO artists (name, sortname) VALUES (\(name.name, sql:.safeQuoted), \(name.sorted, sql:.safeQuoted));"
   }
 }

--- a/Sources/iTunes/RowKind.swift
+++ b/Sources/iTunes/RowKind.swift
@@ -13,12 +13,12 @@ struct RowKind: SQLRow {
 
 extension RowKind: SQLSelectID {
   var selectID: String {
-    "(SELECT id FROM kinds WHERE name = \(kind, sql:.quoted))"
+    "(SELECT id FROM kinds WHERE name = \(kind, sql:.safeQuoted))"
   }
 }
 
 extension RowKind: SQLInsert {
   var insert: String {
-    "INSERT INTO kinds (name) VALUES (\(kind, sql:.quoted));"
+    "INSERT INTO kinds (name) VALUES (\(kind, sql:.safeQuoted));"
   }
 }

--- a/Sources/iTunes/RowSong.swift
+++ b/Sources/iTunes/RowSong.swift
@@ -28,12 +28,12 @@ struct RowSong<
 
 extension RowSong: SQLSelectID {
   var selectID: String {
-    "(SELECT id FROM songs WHERE name = \(name.name, sql:.quoted) AND itunesid = \(itunesid, sql: .quoted) AND artistid = \(artist.selectID) AND albumid = \(album.selectID) AND kindid = \(kind.selectID) AND tracknumber = \(trackNumber) AND year = \(year) AND size = \(size) AND duration = \(duration) AND dateadded = \(dateAdded, sql: .quoted))"
+    "(SELECT id FROM songs WHERE name = \(name.name, sql:.safeQuoted) AND itunesid = \(itunesid, sql: .quoted) AND artistid = \(artist.selectID) AND albumid = \(album.selectID) AND kindid = \(kind.selectID) AND tracknumber = \(trackNumber) AND year = \(year) AND size = \(size) AND duration = \(duration) AND dateadded = \(dateAdded, sql: .quoted))"
   }
 }
 
 extension RowSong: SQLInsert {
   var insert: String {
-    "INSERT INTO songs (name, sortname, itunesid, artistid, albumid, kindid, composer, tracknumber, year, size, duration, dateadded, datereleased, datemodified, comments) VALUES (\(name.name, sql:.quoted), \(name.sorted, sql:.quoted), \(itunesid, sql: .quoted), \(artist.selectID), \(album.selectID), \(kind.selectID), \(composer, sql:.quoted), \(trackNumber), \(year), \(size), \(duration), \(dateAdded, sql:.quoted), \(dateReleased, sql:.quoted), \(dateModified, sql:.quoted), \(comments, sql:.quoted));"
+    "INSERT INTO songs (name, sortname, itunesid, artistid, albumid, kindid, composer, tracknumber, year, size, duration, dateadded, datereleased, datemodified, comments) VALUES (\(name.name, sql:.safeQuoted), \(name.sorted, sql:.safeQuoted), \(itunesid, sql: .quoted), \(artist.selectID), \(album.selectID), \(kind.selectID), \(composer, sql:.safeQuoted), \(trackNumber), \(year), \(size), \(duration), \(dateAdded, sql:.quoted), \(dateReleased, sql:.quoted), \(dateModified, sql:.quoted), \(comments, sql:.safeQuoted));"
   }
 }

--- a/Sources/iTunes/SQL+StringInterpolation.swift
+++ b/Sources/iTunes/SQL+StringInterpolation.swift
@@ -11,7 +11,9 @@ struct SQLStringOptions: OptionSet {
   let rawValue: Int
 
   static let quoted = SQLStringOptions(rawValue: 1 << 0)
-  fileprivate static let quoteEscaped = SQLStringOptions(rawValue: 1 << 1)
+  static let quoteEscaped = SQLStringOptions(rawValue: 1 << 1)
+
+  static let safeQuoted: SQLStringOptions = [.quoted, .quoteEscaped]
 }
 
 extension String.StringInterpolation {
@@ -34,6 +36,6 @@ extension String.StringInterpolation {
   }
 
   mutating func appendInterpolation(_ string: String, sql: SQLStringOptions) {
-    _appendInterpolation(string, sql: sql.union(.quoteEscaped))
+    _appendInterpolation(string, sql: sql)
   }
 }


### PR DESCRIPTION
- this allows that not all strings will be safe-quoted (so no double escapes happen).
- now String can be quoted but not quote-escaped first
- now String can be not quoted nor quote-escaped too!