### PR TITLE
Use fully named StringInterpolation

### DIFF
--- a/Sources/iTunes/RowAlbum.swift
+++ b/Sources/iTunes/RowAlbum.swift
@@ -17,12 +17,12 @@ struct RowAlbum: SQLRow {
 
 extension RowAlbum: SQLSelectID {
   var selectID: String {
-    "(SELECT id FROM albums WHERE name = \(name.name, options:.safeQuoted) AND trackcount = \(trackCount) AND disccount = \(discCount) AND discnumber = \(discNumber) AND compilation = \(compilation))"
+    "(SELECT id FROM albums WHERE name = \(sql: name.name, options:.safeQuoted) AND trackcount = \(sql: trackCount) AND disccount = \(sql: discCount) AND discnumber = \(sql: discNumber) AND compilation = \(sql: compilation))"
   }
 }
 
 extension RowAlbum: SQLInsert {
   var insert: String {
-    "INSERT INTO albums (name, sortname, trackcount, disccount, discnumber, compilation) VALUES (\(name.name, options:.safeQuoted), \(name.sorted, options:.safeQuoted), \(trackCount), \(discCount), \(discNumber), \(compilation));"
+    "INSERT INTO albums (name, sortname, trackcount, disccount, discnumber, compilation) VALUES (\(sql: name.name, options:.safeQuoted), \(sql: name.sorted, options:.safeQuoted), \(sql: trackCount), \(sql: discCount), \(sql: discNumber), \(sql: compilation));"
   }
 }

--- a/Sources/iTunes/RowArtist.swift
+++ b/Sources/iTunes/RowArtist.swift
@@ -17,12 +17,12 @@ struct RowArtist: SQLRow {
 
 extension RowArtist: SQLSelectID {
   var selectID: String {
-    "(SELECT id FROM artists WHERE name = \(name.name, options:.safeQuoted))"
+    "(SELECT id FROM artists WHERE name = \(sql: name.name, options:.safeQuoted))"
   }
 }
 
 extension RowArtist: SQLInsert {
   var insert: String {
-    "INSERT INTO artists (name, sortname) VALUES (\(name.name, options:.safeQuoted), \(name.sorted, options:.safeQuoted));"
+    "INSERT INTO artists (name, sortname) VALUES (\(sql: name.name, options:.safeQuoted), \(sql: name.sorted, options:.safeQuoted));"
   }
 }

--- a/Sources/iTunes/RowKind.swift
+++ b/Sources/iTunes/RowKind.swift
@@ -13,12 +13,12 @@ struct RowKind: SQLRow {
 
 extension RowKind: SQLSelectID {
   var selectID: String {
-    "(SELECT id FROM kinds WHERE name = \(kind, options:.safeQuoted))"
+    "(SELECT id FROM kinds WHERE name = \(sql: kind, options:.safeQuoted))"
   }
 }
 
 extension RowKind: SQLInsert {
   var insert: String {
-    "INSERT INTO kinds (name) VALUES (\(kind, options:.safeQuoted));"
+    "INSERT INTO kinds (name) VALUES (\(sql: kind, options:.safeQuoted));"
   }
 }

--- a/Sources/iTunes/RowPlay.swift
+++ b/Sources/iTunes/RowPlay.swift
@@ -15,6 +15,6 @@ struct RowPlay<Song>: SQLRow where Song: SQLSelectID, Song: Hashable {
 
 extension RowPlay: SQLInsert {
   var insert: String {
-    "INSERT INTO plays (songid, date, delta) VALUES (\(song.selectID), \(date, options:.quoted), \(delta));"
+    "INSERT INTO plays (songid, date, delta) VALUES (\(sql: song.selectID), \(sql: date, options:.quoted), \(sql: delta));"
   }
 }

--- a/Sources/iTunes/RowSong.swift
+++ b/Sources/iTunes/RowSong.swift
@@ -28,12 +28,12 @@ struct RowSong<
 
 extension RowSong: SQLSelectID {
   var selectID: String {
-    "(SELECT id FROM songs WHERE name = \(name.name, options:.safeQuoted) AND itunesid = \(itunesid, options: .quoted) AND artistid = \(artist.selectID) AND albumid = \(album.selectID) AND kindid = \(kind.selectID) AND tracknumber = \(trackNumber) AND year = \(year) AND size = \(size) AND duration = \(duration) AND dateadded = \(dateAdded, options: .quoted))"
+    "(SELECT id FROM songs WHERE name = \(sql: name.name, options:.safeQuoted) AND itunesid = \(sql: itunesid, options: .quoted) AND artistid = \(sql: artist.selectID) AND albumid = \(sql: album.selectID) AND kindid = \(sql: kind.selectID) AND tracknumber = \(sql: trackNumber) AND year = \(sql: year) AND size = \(sql: size) AND duration = \(sql: duration) AND dateadded = \(sql: dateAdded, options: .quoted))"
   }
 }
 
 extension RowSong: SQLInsert {
   var insert: String {
-    "INSERT INTO songs (name, sortname, itunesid, artistid, albumid, kindid, composer, tracknumber, year, size, duration, dateadded, datereleased, datemodified, comments) VALUES (\(name.name, options:.safeQuoted), \(name.sorted, options:.safeQuoted), \(itunesid, options: .quoted), \(artist.selectID), \(album.selectID), \(kind.selectID), \(composer, options:.safeQuoted), \(trackNumber), \(year), \(size), \(duration), \(dateAdded, options:.quoted), \(dateReleased, options:.quoted), \(dateModified, options:.quoted), \(comments, options:.safeQuoted));"
+    "INSERT INTO songs (name, sortname, itunesid, artistid, albumid, kindid, composer, tracknumber, year, size, duration, dateadded, datereleased, datemodified, comments) VALUES (\(sql: name.name, options:.safeQuoted), \(sql: name.sorted, options:.safeQuoted), \(sql: itunesid, options: .quoted), \(sql: artist.selectID), \(sql: album.selectID), \(sql: kind.selectID), \(sql: composer, options:.safeQuoted), \(sql: trackNumber), \(sql: year), \(sql: size), \(sql: duration), \(sql: dateAdded, options:.quoted), \(sql: dateReleased, options:.quoted), \(sql: dateModified, options:.quoted), \(sql: comments, options:.safeQuoted));"
   }
 }

--- a/Sources/iTunes/SQL+StringInterpolation.swift
+++ b/Sources/iTunes/SQL+StringInterpolation.swift
@@ -31,11 +31,19 @@ extension String.StringInterpolation {
     appendLiteral(literal)
   }
 
-  mutating func appendInterpolation(_ number: UInt, options: SQLStringOptions) {
+  mutating func appendInterpolation(sql number: UInt, options: SQLStringOptions = []) {
     appendSQLInterpolation(String(number), options: options)
   }
 
-  mutating func appendInterpolation(_ string: String, options: SQLStringOptions) {
+  mutating func appendInterpolation(sql number: Int, options: SQLStringOptions = []) {
+    appendSQLInterpolation(String(number), options: options)
+  }
+
+  mutating func appendInterpolation(sql number: UInt64, options: SQLStringOptions = []) {
+    appendSQLInterpolation(String(number), options: options)
+  }
+
+  mutating func appendInterpolation(sql string: String, options: SQLStringOptions = []) {
     appendSQLInterpolation(string, options: options)
   }
 }


### PR DESCRIPTION
- options: now defaults to [] so that strings can go in without conversions (particularly SELECT statements).