### PR TITLE
Allow sql: StringInterpolation to emit ? for bindable SQLite3 statements

### DIFF
--- a/Sources/iTunes/SQL+StringInterpolation.swift
+++ b/Sources/iTunes/SQL+StringInterpolation.swift
@@ -16,8 +16,15 @@ struct SQLStringOptions: OptionSet {
   static let safeQuoted: SQLStringOptions = [.quoted, .quoteEscaped]
 }
 
-extension String.StringInterpolation {
+extension DefaultStringInterpolation {
+  static var SQLBindable: Bool = false
+
   mutating private func appendSQLInterpolation(_ string: String, options: SQLStringOptions) {
+    guard !Self.SQLBindable else {
+      appendLiteral("?")
+      return
+    }
+
     let literal =
       options.contains(.quoteEscaped) ? string.replacingOccurrences(of: "'", with: "''") : string
 


### PR DESCRIPTION
- Now that all sql strings go through this func, the output can be globally changed.