### PR TITLE
RowPlay no longer stores its RowSong

### DIFF
--- a/Sources/iTunes/RowPlay.swift
+++ b/Sources/iTunes/RowPlay.swift
@@ -7,14 +7,13 @@
 
 import Foundation
 
-struct RowPlay<Song>: TrackRowItem where Song: SQLSelectID, Song: Hashable {
+struct RowPlay: TrackRowItem {
   let date: String
   let delta: Int
-  let song: Song
 }
 
 extension RowPlay {
-  var insert: String {
-    "INSERT INTO plays (songid, date, delta) VALUES (\(sql: song.selectID), \(sql: date, options:.quoted), \(sql: delta));"
+  func insert(songid: String) -> String {
+    "INSERT INTO plays (songid, date, delta) VALUES (\(sql: songid), \(sql: date, options:.quoted), \(sql: delta));"
   }
 }

--- a/Sources/iTunes/SQLSourceEncoder.swift
+++ b/Sources/iTunes/SQLSourceEncoder.swift
@@ -41,7 +41,7 @@ class SQLSourceEncoder {
 
     private var playStatements: (table: String, statements: [String]) {
       let rows = rowEncoder.playRows
-      return (rows.table, rows.rows.map { $0.insert })
+      return (rows.table, rows.rows.map { $0.0.insert(songid: $0.1.selectID) })
     }
 
     private var tableStatements: [(table: String, statements: [String])] {

--- a/Sources/iTunes/SQLSourceEncoder.swift
+++ b/Sources/iTunes/SQLSourceEncoder.swift
@@ -41,7 +41,7 @@ class SQLSourceEncoder {
 
     private var playStatements: (table: String, statements: [String]) {
       let rows = rowEncoder.playRows
-      return (rows.table, rows.rows.map { $0.0.insert(songid: $0.1.selectID) })
+      return (rows.table, rows.rows.map { $0.play!.insert(songid: $0.song.selectID) })
     }
 
     private var tableStatements: [(table: String, statements: [String])] {

--- a/Sources/iTunes/Track+RowPlay.swift
+++ b/Sources/iTunes/Track+RowPlay.swift
@@ -22,10 +22,10 @@ extension Track {
     songPlayCount > 0 || !datePlayedISO8601.isEmpty
   }
 
-  func rowPlay<Song: SQLSelectID>(using song: Song) -> RowPlay<Song>? {
+  var rowPlay: RowPlay? {
     // Some tracks have play dates, but not play counts. Until that is repaired this table has a CHECK(delta >= 0) constraint.
     guard hasPlayed else { return nil }
 
-    return RowPlay(date: datePlayedISO8601, delta: songPlayCount, song: song)
+    return RowPlay(date: datePlayedISO8601, delta: songPlayCount)
   }
 }

--- a/Sources/iTunes/TrackRow.swift
+++ b/Sources/iTunes/TrackRow.swift
@@ -11,5 +11,5 @@ struct TrackRow {
   typealias SongRow = RowSong<RowArtist, RowAlbum, RowKind>
 
   let song: SongRow
-  let play: RowPlay<SongRow>?
+  let play: RowPlay?
 }

--- a/Sources/iTunes/TrackRowEncoder.swift
+++ b/Sources/iTunes/TrackRowEncoder.swift
@@ -52,12 +52,7 @@ final class TrackRowEncoder {
     (Track.SongTable, Array(songs).sorted(by: { $0.name < $1.name }))
   }
 
-  var playRows: (table: String, rows: [(RowPlay, TrackRow.SongRow)]) {
-    (
-      Track.PlaysTable,
-      rows.filter { $0.play != nil }.map { ($0.play!, $0.song) }.sorted(by: {
-        $0.0.date < $1.0.date
-      })
-    )
+  var playRows: (table: String, rows: [TrackRow]) {
+    (Track.PlaysTable, rows.filter { $0.play != nil }.sorted(by: { $0.play!.date < $1.play!.date }))
   }
 }


### PR DESCRIPTION
- The selectID is passed into its insert func.
- This change allows this to be used by the sqlite library code which will insert with a real known ID value insted of re-selecting it.
- update TrackRowEncoder to store the TrackRows and use these to build the RowPlay inserts.