### PR TITLE
Emit songs into db with SQLITE API

### DIFF
--- a/Sources/iTunes/DBEncoder.swift
+++ b/Sources/iTunes/DBEncoder.swift
@@ -50,10 +50,22 @@ final class DBEncoder {
     return try await emit(table: rows.table, rows: rows.rows)
   }
 
+  private func emitSongs(
+    artistLookup: [RowArtist: Int64], albumLookup: [RowAlbum: Int64], kindLookup: [RowKind: Int64]
+  ) async throws -> [RowSong: Int64] {
+    let rows = rowEncoder.songRows
+    let ids = rows.rows.map {
+      [artistLookup[$0.artist] ?? -1, albumLookup[$0.album] ?? -1, kindLookup[$0.kind] ?? -1]
+    }
+    return try await emit(table: rows.table, rows: rows.rows.map { $0.song }, ids: ids)
+  }
+
   private func emit() async throws {
     let kindLookup = try await emitKinds()
     let artistLookup = try await emitArtists()
     let albumLookup = try await emitAlbums()
+    let songLookup = try await emitSongs(
+      artistLookup: artistLookup, albumLookup: albumLookup, kindLookup: kindLookup)
   }
 
   func encode(_ tracks: [Track]) async throws {

--- a/Sources/iTunes/RowSong+SQLBindable.swift
+++ b/Sources/iTunes/RowSong+SQLBindable.swift
@@ -1,0 +1,60 @@
+//
+//  RowSong+SQLBindable.swift
+//
+//
+//  Created by Greg Bolsinga on 1/9/24.
+//
+
+import Foundation
+
+extension RowSong: SQLBindableInsert {
+  static var insertBinding: String {
+    Self.bound {
+      RowSong(
+        name: SortableName(), itunesid: 0, composer: "", trackNumber: 0, year: 0, size: 0,
+        duration: 0, dateAdded: "", dateReleased: "", dateModified: "", comments: ""
+      ).insert(artistID: "", albumID: "", kindID: "")
+    }
+  }
+
+  func bindInsert(db: Database, statement: Database.Statement, ids: [Int64]) throws {
+    guard ids.count == 3 else { throw SQLBindingError.iDsRequired }
+
+    try statement.bind(db: db, count: 15) { index in
+      switch index {
+      case 1:
+        Database.Value.string(name.name)
+      case 2:
+        Database.Value.string(name.sorted)
+      case 3:
+        Database.Value.string(String(itunesid))
+      case 4:
+        Database.Value.string(String(composer))
+      case 5:
+        Database.Value.integer(Int64(trackNumber))
+      case 6:
+        Database.Value.integer(Int64(year))
+      case 7:
+        Database.Value.integer(Int64(size))
+      case 8:
+        Database.Value.integer(Int64(duration))
+      case 9:
+        Database.Value.string(dateAdded)
+      case 10:
+        Database.Value.string(dateReleased)
+      case 11:
+        Database.Value.string(dateModified)
+      case 12:
+        Database.Value.string(comments)
+      case 13:
+        Database.Value.integer(ids[0])
+      case 14:
+        Database.Value.integer(ids[1])
+      case 15:
+        Database.Value.integer(ids[2])
+      default:
+        preconditionFailure()
+      }
+    }
+  }
+}

--- a/Sources/iTunes/SQLBindableStatement.swift
+++ b/Sources/iTunes/SQLBindableStatement.swift
@@ -20,6 +20,7 @@ extension SQLBindableStatement {
 
 enum SQLBindingError: Error {
   case noIDsRequired
+  case iDsRequired
 }
 
 protocol SQLBindableInsert: SQLBindableStatement {


### PR DESCRIPTION
- Use the tracked IDs and bind those instead of select statements as is done in the SQL source export.