### PR TITLE
Allow outpufile naming

### DIFF
--- a/Sources/iTunes/Destination+URL.swift
+++ b/Sources/iTunes/Destination+URL.swift
@@ -8,11 +8,15 @@
 import Foundation
 
 extension Destination {
-  public func outputFile(using directory: URL) -> URL? {
+  fileprivate var defaultName: String {
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "yyyy-MM-dd"
     let dateString = dateFormatter.string(from: Date())
+    return "iTunes-\(dateString)"
+  }
 
-    return directory.appending(path: "iTunes-\(dateString).\(self.filenameExtension)")
+  public func outputFile(using directory: URL, name: String? = nil) -> URL? {
+    let name = name ?? defaultName
+    return directory.appending(path: "\(name).\(self.filenameExtension)")
   }
 }

--- a/Sources/iTunes/Destination+URL.swift
+++ b/Sources/iTunes/Destination+URL.swift
@@ -15,7 +15,7 @@ extension Destination {
     return "iTunes-\(dateString)"
   }
 
-  public func outputFile(using directory: URL, name: String? = nil) -> URL? {
+  public func outputFile(using directory: URL, name: String?) -> URL? {
     let name = name ?? defaultName
     return directory.appending(path: "\(name).\(self.filenameExtension)")
   }

--- a/Sources/tool/Program.swift
+++ b/Sources/tool/Program.swift
@@ -16,7 +16,7 @@ struct Program: AsyncParsableCommand {
   /// Optional Output Directory for output file.
   @Option(
     help:
-      "The path at which to create the output file. The file name will be based upon the date and the --destination. If possible, writes to standard output if not provided.",
+      "The path at which to create the output file. If possible, writes to standard output if not provided.",
     transform: ({
       let url = URL(filePath: $0, directoryHint: .isDirectory)
       let manager = FileManager.default
@@ -47,11 +47,18 @@ struct Program: AsyncParsableCommand {
   )
   var jsonSource: String?
 
+  /// Optional file name to use. Default is 'iTunes-yyyy-MM-dd". Its extension is always based upon the --destination.
+  @Option(
+    help:
+      "Optional file name to use when outputDirectory is used. If not set, the file name will be based upon the current date."
+  )
+  var fileName: String?
+
   /// Outputfile where data will be writen, if outputDirectory is not specified.
   private var outputFile: URL? {
     guard let outputDirectory else { return nil }
 
-    return destination.outputFile(using: outputDirectory)
+    return destination.outputFile(using: outputDirectory, name: fileName)
   }
 
   /// Validates the input matrix.


### PR DESCRIPTION
- This will allow batch processing scripts to name the file instead of always using today's date, or using re-direction.
- This is necessary since redirection is not possible when using the sqlite3 library API.