### PR TITLE
journal_mode WAL and synchronous NORMAL

### DIFF
--- a/Sources/iTunes/Database.swift
+++ b/Sources/iTunes/Database.swift
@@ -24,6 +24,8 @@ extension Logger {
 
 enum DatabaseError: Error {
   case cannotOpen(String)
+  case cannotEnableWALJournaling(String)
+  case cannotEnableSynchrounsNormal(String)
   case cannotExecute(String)
   case cannotPrepare(String)
   case cannotBind(String)
@@ -124,6 +126,13 @@ actor Database {
     guard result == SQLITE_OK else { throw DatabaseError.cannotOpen(handle.sqlError) }
 
     self.handle = handle
+
+    guard sqlite3_exec(handle, "PRAGMA journal_mode = WAL", nil, nil, nil) == SQLITE_OK else {
+      throw DatabaseError.cannotEnableWALJournaling(handle.sqlError)
+    }
+    guard sqlite3_exec(handle, "PRAGMA synchronous = NORMAL", nil, nil, nil) == SQLITE_OK else {
+      throw DatabaseError.cannotEnableSynchrounsNormal(handle.sqlError)
+    }
   }
 
   deinit {


### PR DESCRIPTION
- time to build full db (from iTunesLibrary) today goes from 13 to 2 seconds.
- tried to integrate SQLITE_FCNTL_PERSIST_WAL, but would get logs about the -shm file, even though afterwards there were no extraneous files.