### PR TITLE
Add TimeTest

### DIFF
--- a/Sources/iTunes/TimeTest.swift
+++ b/Sources/iTunes/TimeTest.swift
@@ -1,0 +1,120 @@
+//
+//  TimeTest.swift
+//
+//
+//  Created by Greg Bolsinga on 1/15/24.
+//
+
+import Carbon
+import Foundation
+
+private let validTime = "2004-02-04T23:32:22Z"
+private let validTimestamp = Double(1_075_937_542)
+private let invalidTime = "2004-02-05T00:32:22Z"
+private let invalidTimestamp = Double(1_075_941_142)
+private let json = """
+  { "v" : "2004-02-04T23:32:22Z", "i" : "2004-02-05T00:32:22Z" }
+  """.data(using: .utf8)!
+
+private enum TimeTestError: Error {
+  case parseValidError
+  case parseInvalidError
+  case bothError
+
+  case jsonParseValidError
+  case jsonParseInvalidError
+  case jsonBothError
+
+  case chetAtkinsMissing
+  case chetAtkinsChanged
+
+  var result: Int {
+    switch self {
+    case .parseValidError:
+      return 1
+    case .parseInvalidError:
+      return 2
+    case .bothError:
+      return 3
+    case .jsonParseValidError:
+      return 4
+    case .jsonParseInvalidError:
+      return 5
+    case .jsonBothError:
+      return 6
+    case .chetAtkinsMissing:
+      return 7
+    case .chetAtkinsChanged:
+      return 8
+    }
+  }
+}
+
+private struct S: Decodable {
+  let v: Date?
+  let i: Date?
+}
+
+public func testTime() async -> Int {
+  var result = 0
+  do {
+    try await validateTimeParsing()
+  } catch {
+    if let tError = error as? TimeTestError {
+      result = tError.result
+    } else {
+      result = 100
+    }
+  }
+  return result
+}
+
+private func validateTimeParsing() async throws {
+  let validDate = ISO8601DateFormatter().date(from: validTime)
+
+  let parseValidDate = validDate?.timeIntervalSince1970 == validTimestamp
+
+  let invalidDate = ISO8601DateFormatter().date(from: invalidTime)
+
+  let parseInvalidDate = invalidDate?.timeIntervalSince1970 == invalidTimestamp
+
+  if !parseValidDate || !parseInvalidDate {
+    if !parseValidDate && !parseInvalidDate {
+      throw TimeTestError.bothError
+    }
+    if !parseValidDate {
+      throw TimeTestError.parseValidError
+    }
+    throw TimeTestError.parseInvalidError
+  }
+
+  let decoder = JSONDecoder()
+  decoder.dateDecodingStrategy = .iso8601
+
+  let s = try decoder.decode(S.self, from: json)
+
+  let jsonParseValidDate = s.v == validDate
+
+  let jsonParseInvalidDate = s.i == invalidDate
+
+  if !jsonParseValidDate || !jsonParseInvalidDate {
+    if !jsonParseValidDate && !jsonParseInvalidDate {
+      throw TimeTestError.jsonBothError
+    }
+    if !jsonParseValidDate {
+      throw TimeTestError.jsonParseValidError
+    }
+    throw TimeTestError.jsonParseInvalidError
+  }
+
+  let chetAtkinsYesterday = try await Source.itunes.gather(nil).filter {
+    $0.persistentID == 17_859_820_717_873_205_520
+  }
+  if chetAtkinsYesterday.isEmpty {
+    throw TimeTestError.chetAtkinsMissing
+  }
+  let chetAtkinsYesterdayExpectedDate = chetAtkinsYesterday.first!.playDateUTC == validDate
+  if !chetAtkinsYesterdayExpectedDate {
+    throw TimeTestError.chetAtkinsChanged
+  }
+}

--- a/Sources/tool/Program.swift
+++ b/Sources/tool/Program.swift
@@ -54,6 +54,9 @@ struct Program: AsyncParsableCommand {
   )
   var fileName: String?
 
+  @Flag
+  var timeTest = false
+
   /// Outputfile where data will be writen, if outputDirectory is not specified.
   private var outputFile: URL? {
     guard let outputDirectory else { return nil }
@@ -91,6 +94,12 @@ struct Program: AsyncParsableCommand {
   }
 
   func run() async throws {
+    guard !timeTest else {
+      let result = await testTime()
+      if result != 0 { throw ExitCode(Int32(result)) }
+      return
+    }
+
     let tracks = try await {
       let t = try await source.gather(jsonSource)
       if isRepairing {


### PR DESCRIPTION
- This is a mode for the program that can be run daily to see if anything weird happens with these timestamps.
- It winds up being a exit code since I was unable to run AppleScript to show a notification from within this cmd-line app.
- The calling shell script can use `osascript` to display a notification if it fails.