### PR TITLE
Use the sentinel Track to repair off by one hour dates

### DIFF
--- a/Sources/iTunes/Repair.swift
+++ b/Sources/iTunes/Repair.swift
@@ -115,14 +115,19 @@ public struct Repair {
   let items: [Item]
 
   func repair(_ tracks: [Track]) -> [Track] {
+    var datesAreAheadOneHour = false
+
     let fixes = tracks.reduce(into: [Track: [Fix]]()) { dictionary, track in
+      if !datesAreAheadOneHour {
+        datesAreAheadOneHour = track.datesAreAheadOneHour
+      }
       var arr = dictionary[track] ?? []
       arr.append(
         contentsOf: items.filter { track.matches(problem: $0.problem) }.compactMap { $0.fix })
       if !arr.isEmpty { dictionary[track] = arr }
     }
 
-    guard !fixes.isEmpty else { return tracks }
+    guard !fixes.isEmpty || datesAreAheadOneHour else { return tracks }
 
     return tracks.compactMap { track in
       if let fixes = fixes[track], !fixes.isEmpty {
@@ -132,9 +137,9 @@ public struct Repair {
             fixedTrack = repairedTrack.repair($0)
           }
         }
-        return fixedTrack
+        return datesAreAheadOneHour ? fixedTrack?.moveDatesBackOneHour() : fixedTrack
       }
-      return track
+      return datesAreAheadOneHour ? track.moveDatesBackOneHour() : track
     }
   }
 }

--- a/Sources/iTunes/Track+OffsetDate.swift
+++ b/Sources/iTunes/Track+OffsetDate.swift
@@ -17,4 +17,58 @@ extension Track {
     // "Yesterday" by Chet Atkins has not been played since before this data has been saved.
     persistentID == 17_859_820_717_873_205_520
   }
+
+  private var playDateUTCIsSentinelDate: Bool {
+    playDateUTC?.timeIntervalSince1970 == Double.timeIntervalSince1970ValidSentinel
+  }
+
+  var datesAreAheadOneHour: Bool {
+    isValidDateCheckSentinel && !playDateUTCIsSentinelDate
+  }
+
+  func moveDatesBackOneHour() -> Track {
+    let calendar = Calendar.autoupdatingCurrent
+
+    let cDateAdded: Date? = {
+      guard let dateAdded else { return nil }
+      return calendar.date(byAdding: .hour, value: -1, to: dateAdded)
+    }()
+    let cDateModified: Date? = {
+      guard let dateModified else { return nil }
+      return calendar.date(byAdding: .hour, value: -1, to: dateModified)
+    }()
+    let cPlayDate: Date? = {
+      guard let playDateUTC else { return nil }
+      return calendar.date(byAdding: .hour, value: -1, to: playDateUTC)
+    }()
+    let cReleaseDate: Date? = {
+      //      guard let releaseDate else { return nil }
+      //      return calendar.date(byAdding: .hour, value: -1, to: releaseDate)
+      /// Strangely, the releaseDate does not seem to be offset.
+      releaseDate
+    }()
+    let cSkipDate: Date? = {
+      guard let skipDate else { return nil }
+      return calendar.date(byAdding: .hour, value: -1, to: skipDate)
+    }()
+
+    return Track(
+      album: album, albumArtist: albumArtist, albumRating: albumRating,
+      albumRatingComputed: albumRatingComputed, artist: artist, bitRate: bitRate, bPM: bPM,
+      comments: comments, compilation: compilation, composer: composer,
+      contentRating: contentRating, dateAdded: cDateAdded, dateModified: cDateModified,
+      disabled: disabled, discCount: discCount, discNumber: discNumber, episode: episode,
+      episodeOrder: episodeOrder, explicit: explicit, genre: genre, grouping: grouping,
+      hasVideo: hasVideo, hD: hD, kind: kind, location: location, movie: movie,
+      musicVideo: musicVideo, name: name, partOfGaplessAlbum: partOfGaplessAlbum,
+      persistentID: persistentID, playCount: playCount, playDateUTC: cPlayDate,
+      podcast: podcast, protected: protected, purchased: purchased, rating: rating,
+      ratingComputed: ratingComputed, releaseDate: cReleaseDate, sampleRate: sampleRate,
+      season: season, series: series, size: size, skipCount: skipCount, skipDate: cSkipDate,
+      sortAlbum: sortAlbum, sortAlbumArtist: sortAlbumArtist, sortArtist: sortArtist,
+      sortComposer: sortComposer, sortName: sortName, sortSeries: sortSeries,
+      totalTime: totalTime, trackCount: trackCount, trackNumber: trackNumber,
+      trackType: trackType, tVShow: tVShow, unplayed: unplayed, videoHeight: videoHeight,
+      videoWidth: videoWidth, year: year)
+  }
 }


### PR DESCRIPTION
- This is only done when repairing JSON data. The assumption is that new data will be flagged by --time-test running nightly.