### PR TITLE
sort the tracks prior to emitting output

### DIFF
--- a/Sources/iTunes/Destination+Tracks.swift
+++ b/Sources/iTunes/Destination+Tracks.swift
@@ -17,6 +17,8 @@ extension Destination {
       throw DataExportError.noTracks
     }
 
+    let tracks = tracks.sorted { $0.persistentID < $1.persistentID }
+
     switch self {
     case .json, .sqlCode:
       let data = try self.data(for: tracks)


### PR DESCRIPTION
- this is helpful when trying to learn what changes have happened.