### PR TITLE
Refactor For TrackRowEncoder

### DIFF
--- a/Sources/iTunes/Array+DB.swift
+++ b/Sources/iTunes/Array+DB.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Array where Element == Track {
   public func database(file: URL) async throws {
-    let encoder = try DBEncoder(file: file, minimumCapacity: self.count)
-    try await encoder.encode(self)
+    let encoder = try DBEncoder(file: file, rowEncoder: self.rowEncoder)
+    try await encoder.encode()
   }
 }

--- a/Sources/iTunes/Array+TrackRow.swift
+++ b/Sources/iTunes/Array+TrackRow.swift
@@ -1,0 +1,21 @@
+//
+//  Array+TrackRow.swift
+//
+//
+//  Created by Greg Bolsinga on 1/18/24.
+//
+
+import Foundation
+
+extension Track {
+  fileprivate var trackRow: TrackRow {
+    TrackRow(
+      album: RowAlbum(self), artist: RowArtist(self), song: RowSong(self), play: RowPlay(self))
+  }
+}
+
+extension Array where Element == Track {
+  var rowEncoder: TrackRowEncoder {
+    TrackRowEncoder(rows: self.filter { $0.isSQLEncodable }.map { $0.trackRow })
+  }
+}

--- a/Sources/iTunes/SQLSourceEncoder.swift
+++ b/Sources/iTunes/SQLSourceEncoder.swift
@@ -15,12 +15,8 @@ struct SQLSourceEncoder {
   fileprivate struct Encoder {
     private let rowEncoder: TrackRowEncoder
 
-    init(minimumCapacity: Int) {
-      self.rowEncoder = TrackRowEncoder(minimumCapacity: minimumCapacity)
-    }
-
-    fileprivate func encode(_ track: Track) {
-      rowEncoder.encode(track)
+    init(rowEncoder: TrackRowEncoder) {
+      self.rowEncoder = rowEncoder
     }
 
     private var artistStatements: (table: String, statements: [String]) {
@@ -67,9 +63,8 @@ struct SQLSourceEncoder {
     }
   }
 
-  func encode(_ tracks: [Track]) throws -> String {
-    let encoder = Encoder(minimumCapacity: tracks.count)
-    tracks.filter { $0.isSQLEncodable }.forEach { encoder.encode($0) }
+  private func encode(_ tracks: [Track]) throws -> String {
+    let encoder = Encoder(rowEncoder: tracks.rowEncoder)
     return encoder.sqlStatements
   }
 

--- a/Sources/iTunes/TrackRowEncoder.swift
+++ b/Sources/iTunes/TrackRowEncoder.swift
@@ -12,23 +12,8 @@ extension Logger {
   static let duplicateArtist = Logger(subsystem: "validation", category: "duplicateArtist")
 }
 
-extension Track {
-  fileprivate var trackRow: TrackRow {
-    TrackRow(
-      album: RowAlbum(self), artist: RowArtist(self), song: RowSong(self), play: RowPlay(self))
-  }
-}
-
-final class TrackRowEncoder {
-  private var rows = [TrackRow]()
-
-  init(minimumCapacity: Int) {
-    self.rows.reserveCapacity(minimumCapacity)
-  }
-
-  func encode(_ track: Track) {
-    rows.append(track.trackRow)
-  }
+struct TrackRowEncoder {
+  let rows: [TrackRow]
 
   var artistRows: (table: String, rows: [RowArtist]) {
     let artistRows = Array(Set(rows.map { $0.artist }))


### PR DESCRIPTION
- now it is only created in one place.
- the filter for sql only items also appears in one place.
- the array of TrackRows is created with collection map, so setting the size of an array is not necesssary.
- TrackRowEncoder is no longer mutable since it is instantiated with all its data. So it can be a struct.