### PR TITLE
sort by a track's traits not persistentID

### DIFF
--- a/Sources/iTunes/Destination+Tracks.swift
+++ b/Sources/iTunes/Destination+Tracks.swift
@@ -17,7 +17,7 @@ extension Destination {
       throw DataExportError.noTracks
     }
 
-    let tracks = tracks.sorted { $0.persistentID < $1.persistentID }
+    let tracks = tracks.sorted()
 
     switch self {
     case .json, .sqlCode:

--- a/Sources/iTunes/Track+Comparable.swift
+++ b/Sources/iTunes/Track+Comparable.swift
@@ -1,0 +1,42 @@
+//
+//  Track+Comparable.swift
+//
+//
+//  Created by Greg Bolsinga on 1/19/24.
+//
+
+import Foundation
+
+extension Track: Comparable {
+  fileprivate var compareArtist: String {
+    (sortArtist ?? sortAlbumArtist) ?? (artist ?? albumArtist ?? "")
+  }
+
+  fileprivate var compareAlbum: String { sortAlbum ?? album ?? "" }
+
+  fileprivate var compareDiscNumber: Int { discNumber ?? 1 }
+
+  fileprivate var compareTrackNumber: Int { trackNumber ?? 1 }
+
+  public static func < (lhs: Track, rhs: Track) -> Bool {
+    let lhArtist = lhs.compareArtist
+    let rhArtist = rhs.compareArtist
+
+    if lhArtist == rhArtist {
+      let lhAlbum = lhs.compareAlbum
+      let rhAlbum = rhs.compareAlbum
+
+      if lhAlbum == rhAlbum {
+        let lhDiscNumber = lhs.compareDiscNumber
+        let rhDiscNumber = rhs.compareDiscNumber
+
+        if lhDiscNumber == rhDiscNumber {
+          return lhs.compareTrackNumber < rhs.compareTrackNumber
+        }
+        return lhDiscNumber < rhDiscNumber
+      }
+      return lhAlbum < rhAlbum
+    }
+    return lhArtist < rhArtist
+  }
+}


### PR DESCRIPTION
- by looking at repaired json diffs that are sorted, it is clear persistentID is not always consistent over time.