### PR TITLE
Add Track.pruned and use it in Repair.

### DIFF
--- a/Sources/iTunes/Repair.swift
+++ b/Sources/iTunes/Repair.swift
@@ -117,6 +117,7 @@ public struct Repair {
   func repair(_ tracks: [Track]) -> [Track] {
     var datesAreAheadOneHour = false
 
+    let tracks = tracks.filter { $0.isSQLEncodable }.map { $0.pruned }
     let fixes = tracks.reduce(into: [Track: [Fix]]()) { dictionary, track in
       if !datesAreAheadOneHour {
         datesAreAheadOneHour = track.datesAreAheadOneHour

--- a/Sources/iTunes/Track+Prune.swift
+++ b/Sources/iTunes/Track+Prune.swift
@@ -1,0 +1,31 @@
+//
+//  Track+Prune.swift
+//
+//
+//  Created by Greg Bolsinga on 1/19/24.
+//
+
+import Foundation
+
+extension Track {
+  var pruned : Track {
+    return Track(
+      album: album, albumArtist: albumArtist, albumRating: nil,
+      albumRatingComputed: nil, artist: artist, bitRate: nil, bPM: nil,
+      comments: comments, compilation: compilation, composer: composer,
+      contentRating: nil, dateAdded: dateAdded, dateModified: nil,
+      disabled: nil, discCount: discCount, discNumber: discNumber, episode: nil,
+      episodeOrder: nil, explicit: nil, genre: nil, grouping: nil,
+      hasVideo: nil, hD: nil, kind: nil, location: nil, movie: nil,
+      musicVideo: nil, name: name, partOfGaplessAlbum: nil,
+      persistentID: persistentID, playCount: playCount, playDateUTC: playDateUTC,
+      podcast: nil, protected: nil, purchased: nil, rating: nil,
+      ratingComputed: nil, releaseDate: releaseDate, sampleRate: nil,
+      season: nil, series: nil, size: nil, skipCount: nil, skipDate: nil,
+      sortAlbum: sortAlbum, sortAlbumArtist: sortAlbumArtist, sortArtist: sortArtist,
+      sortComposer: nil, sortName: sortName, sortSeries: nil,
+      totalTime: totalTime, trackCount: trackCount, trackNumber: trackNumber,
+      trackType: nil, tVShow: nil, unplayed: nil, videoHeight: nil,
+      videoWidth: nil, year: year)
+  }
+}


### PR DESCRIPTION
- Track.pruned prunes out all the fields that are not used for the database.
- The idea is that databases will only be made from repaired json files. 
-- The nightly backup will continue to get all the fields it can. 
-- Repair will happen, which will include pruning unecessary fields, and removing Tracks that are not SQL Encodable entirely. 
--- This will make the repaired JSON smaller with only relevant data. 
--- This in turn will make it simpler to understand what still needs to be reapaired.