### PR TITLE
add more logging about invalid plays

### DIFF
--- a/Sources/iTunes/RowPlay.swift
+++ b/Sources/iTunes/RowPlay.swift
@@ -6,30 +6,18 @@
 //
 
 import Foundation
-import os
-
-extension Logger {
-  static let brokenPlayDate = Logger(subsystem: "validation", category: "brokenPlayDate")
-}
 
 protocol RowPlayInterface {
-  var datePlayedISO8601: String { get }
-  var songPlayCount: Int { get }
+  var songPlayedInformation: (datePlayedISO8601: String, playCount: Int) { get }
 }
 
 struct RowPlay: Hashable {
   init?(_ play: RowPlayInterface) {
-    let songPlayCount = play.songPlayCount
-    let datePlayed = play.datePlayedISO8601
+    let info = play.songPlayedInformation
 
-    // Some tracks have had play dates, but not play counts. This table also has a CHECK(delta > 0) constraint.
-    if songPlayCount == 0, !datePlayed.isEmpty {
-      Logger.brokenPlayDate.error("")
-    }
+    guard info.playCount > 0 || !info.datePlayedISO8601.isEmpty else { return nil }
 
-    guard songPlayCount > 0 || !datePlayed.isEmpty else { return nil }
-
-    self.init(date: datePlayed, delta: songPlayCount)
+    self.init(date: info.datePlayedISO8601, delta: info.playCount)
   }
 
   init() {

--- a/Sources/iTunes/Track+RowPlay.swift
+++ b/Sources/iTunes/Track+RowPlay.swift
@@ -6,14 +6,37 @@
 //
 
 import Foundation
+import os
+
+extension Logger {
+  static let noPlayDate = Logger(subsystem: "validation", category: "noPlayDate")
+  static let noPlayCount = Logger(subsystem: "validation", category: "noPlayCount")
+}
 
 extension Track: RowPlayInterface {
-  var datePlayedISO8601: String {
+  var songPlayedInformation: (datePlayedISO8601: String, playCount: Int) {
+    let datePlayed = datePlayedISO8601
+    let playCount = songPlayCount
+
+    if datePlayed.isEmpty || playCount == 0 {
+      if playCount != 0 {
+        Logger.noPlayDate.error("\(debugLogInformation, privacy: .public)")
+      }
+      if !datePlayed.isEmpty {
+        Logger.noPlayCount.error("\(debugLogInformation, privacy: .public)")
+      }
+    }
+
+    return (datePlayed, playCount)
+  }
+
+  private var datePlayedISO8601: String {
     guard let playDateUTC else { return "" }
     return playDateUTC.formatted(.iso8601)
   }
 
-  var songPlayCount: Int {
-    playCount ?? 0
+  private var songPlayCount: Int {
+    guard let playCount else { return 0 }
+    return playCount
   }
 }


### PR DESCRIPTION
- also get the play information only once, so that the logs only occur once.
- This finds things like the following in code. Still have to work out a fix! -- It has 3 plays without a playDate, and "later" it has 2 plays, but a playDate.

```
neu:git bolsinga$ sqlite3 ../../dbs/iTunes-2007-10-01/*.db
sqlite> SELECT * FROM plays WHERE id=1;
1|4635||3
sqlite> SELECT * FROM songs WHERE id=4635;
4635|Mine's Not a High Horse||8565408148774723979|377|119||2|2003|200224|2007-08-29T03:34:50Z|2003-10-21T07:00:00Z|
sqlite> .exit
neu:git bolsinga$ sqlite3 ../../dbs/iTunes-2011-08-01/*.db
sqlite> SELECT * FROM plays WHERE id=2328;
2328|5801|2009-01-16T23:28:39Z|2
sqlite> SELECT * FROM songs WHERE id=5801;
5801|Mine's Not a High Horse||8565408148774723979|504|154||2|2003|200226|2007-08-29T03:34:50Z|2003-10-21T07:00:00Z|
```