### PR TITLE
allow any source to be repaired

### DIFF
--- a/Sources/iTunes/Source+Tracks.swift
+++ b/Sources/iTunes/Source+Tracks.swift
@@ -9,14 +9,18 @@ import Foundation
 
 extension Source {
   public func gather(_ source: String?, repair: Repair?) async throws -> [Track] {
+    let tracks = try await gather(source)
+    return repair != nil ? repair!.repair(tracks) : tracks
+  }
+
+  private func gather(_ source: String?) async throws -> [Track] {
     switch self {
     case .itunes:
       return try Track.gatherAllTracks()
     case .musickit:
       return try await Track.gatherWithMusicKit()
     case .jsonString:
-      let tracks = try Track.createFromString(source)
-      return repair != nil ? repair!.repair(tracks) : tracks
+      return try Track.createFromString(source)
     }
   }
 }

--- a/Sources/tool/Program.swift
+++ b/Sources/tool/Program.swift
@@ -74,11 +74,6 @@ struct Program: AsyncParsableCommand {
       throw ValidationError("Using --json-string requires JSON String to be passed as an argument.")
     }
 
-    if isRepairing && (source != .jsonString) {
-      throw ValidationError(
-        "Repairing requires source json (actually \(source)) to be converted."
-      )
-    }
     if (repairFile != nil) && (repairSource != nil) {
       throw ValidationError("repairSource is already defined, but repairFile is being passed.")
     }


### PR DESCRIPTION
- this is useful during "bring up of clean data".
- it may be useful to disable this once itunes contains clean data, but right now it has files that have play dates, but not play counts.