### PR TITLE
trackCount and trackNumber zero are also valid repair states.

### DIFF
--- a/Sources/iTunes/Repair/Track+Issue.swift
+++ b/Sources/iTunes/Repair/Track+Issue.swift
@@ -49,9 +49,11 @@ extension Track {
     case .repairEmptyYear(_):
       return year == nil
     case .repairEmptyTrackCount(_):
-      return trackCount == nil
+      guard let trackCount else { return true }
+      return trackCount == 0
     case .repairEmptyTrackNumber(_):
-      return trackNumber == nil
+      guard let trackNumber else { return true }
+      return trackNumber == 0
     case .repairEmptyAlbum(_):
       return album == nil
     case .replaceArtist(_):

--- a/Tests/iTunes/RemedyTrackApplicableTests.swift
+++ b/Tests/iTunes/RemedyTrackApplicableTests.swift
@@ -37,12 +37,14 @@ final class RemedyTrackApplicableTests: XCTestCase {
 
   func testRepairEmptyTrackCount() throws {
     XCTAssertTrue(Track(name: "s", persistentID: 0).remedyApplies(.repairEmptyTrackCount(3)))
+    XCTAssertTrue(Track(name: "s", persistentID: 0, trackCount: 0).remedyApplies(.repairEmptyTrackCount(3)))
     XCTAssertFalse(
       Track(name: "s", persistentID: 0, trackCount: 2).remedyApplies(.repairEmptyTrackCount(3)))
   }
 
   func testRepairEmptyTrackNumber() throws {
     XCTAssertTrue(Track(name: "s", persistentID: 0).remedyApplies(.repairEmptyTrackNumber(3)))
+    XCTAssertTrue(Track(name: "s", persistentID: 0, trackNumber: 0).remedyApplies(.repairEmptyTrackNumber(3)))
     XCTAssertFalse(
       Track(name: "s", persistentID: 0, trackNumber: 2).remedyApplies(.repairEmptyTrackNumber(3)))
   }


### PR DESCRIPTION
- Add tests that fail w/o the code changes.