### PR TITLE
Emit Item repair data for duplicate track play dates

### DIFF
--- a/Sources/iTunes/Array+TracksDuplicatePlayDate.swift
+++ b/Sources/iTunes/Array+TracksDuplicatePlayDate.swift
@@ -1,0 +1,25 @@
+//
+//  Array+TracksDuplicatePlayDate.swift
+//
+//
+//  Created by Greg Bolsinga on 2/16/24.
+//
+
+import Foundation
+
+extension Array where Element == Track {
+  var duplicatePlayDateItems: [Item] {
+    // group by playdate. find those with more than one Track.
+    let duplicates = Dictionary(grouping: self.filter { $0.playDateUTC != nil }) { $0.playDateUTC! }
+      .filter { $0.value.count > 1 }
+
+    return duplicates.flatMap {
+      var date = $0
+      return $1.reduce(into: [Item]()) {
+        // Bump the date of everything by one more second so they are unique.
+        date = date.addingTimeInterval(1)
+        $0.append($1.itemWithFixPlayDate(date))
+      }
+    }
+  }
+}

--- a/Sources/iTunes/Destination+Data.swift
+++ b/Sources/iTunes/Destination+Data.swift
@@ -16,6 +16,8 @@ extension Destination {
       return try tracks.sqlData()
     case .db:
       preconditionFailure("No Data for db")
+    case .duplicates:
+      return try tracks.duplicatePlayDateItems.jsonData()
     }
   }
 }

--- a/Sources/iTunes/Destination+FileNameExtension.swift
+++ b/Sources/iTunes/Destination+FileNameExtension.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Destination {
   var filenameExtension: String {
     switch self {
-    case .json:
+    case .json, .duplicates:
       "json"
     case .sqlCode:
       "sql"

--- a/Sources/iTunes/Destination+Tracks.swift
+++ b/Sources/iTunes/Destination+Tracks.swift
@@ -20,7 +20,7 @@ extension Destination {
     let tracks = tracks.sorted()
 
     switch self {
-    case .json, .sqlCode:
+    case .json, .sqlCode, .duplicates:
       let data = try self.data(for: tracks)
 
       if let outputFile {

--- a/Sources/iTunes/Destination.swift
+++ b/Sources/iTunes/Destination.swift
@@ -15,4 +15,6 @@ public enum Destination: CaseIterable {
   case sqlCode
   /// Emit a sqlite3 database that represents the Tracks.
   case db
+  /// Emit duplicate play date Track data.
+  case duplicates
 }

--- a/Sources/iTunes/Track+Item.swift
+++ b/Sources/iTunes/Track+Item.swift
@@ -1,0 +1,27 @@
+//
+//  Track+Item.swift
+//
+//
+//  Created by Greg Bolsinga on 2/16/24.
+//
+
+import Foundation
+
+extension TrackRow {
+  fileprivate func itemWithFixPlayDate(_ playDate: Date) -> Item {
+    Item(problem: problem, fix: Fix(playDate: playDate))
+  }
+
+  fileprivate var problem: Problem {
+    Problem(
+      artist: self.artist.name.name, album: self.album.name.name, name: self.song.name.name,
+      playCount: self.play != nil ? self.play!.delta : nil,
+      playDate: self.play != nil ? ISO8601DateFormatter().date(from: self.play!.date) : nil)
+  }
+}
+
+extension Track {
+  func itemWithFixPlayDate(_ playDate: Date) -> Item {
+    trackRow.itemWithFixPlayDate(playDate)
+  }
+}


### PR DESCRIPTION
- Run with `--duplicates` and the program will load repaired data, and emit repair json for the duplicate play date tracks.
- Each track with a duplicate play date will increment by 1 second so they are unique.
- Most of these songs are played again at some point, so the data "becomes better eventually".
- This will allow `UNIQUE(date)` to be added to the plays table schema.