### PR TITLE
Allow Tracks to be ignored by persistentID

### DIFF
--- a/Sources/iTunes/Repair/Criterion.swift
+++ b/Sources/iTunes/Repair/Criterion.swift
@@ -13,6 +13,7 @@ enum Criterion: Hashable {
   case song(String)
   case playCount(Int)
   case playDate(Date)
+  case persistentId(UInt)
 
   func matchesAlbum(_ album: String) -> Bool {
     switch self {
@@ -54,6 +55,15 @@ enum Criterion: Hashable {
     switch self {
     case .playDate(let date):
       return date == playDate
+    default:
+      return false
+    }
+  }
+
+  func matchesPersistentId(_ persistentID: UInt) -> Bool {
+    switch self {
+    case .persistentId(let uint):
+      return persistentID == uint
     default:
       return false
     }

--- a/Sources/iTunes/Repair/Item.swift
+++ b/Sources/iTunes/Repair/Item.swift
@@ -10,13 +10,14 @@ import Foundation
 struct Problem: Codable, Hashable {
   internal init(
     artist: String? = nil, album: String? = nil, name: String? = nil, playCount: Int? = nil,
-    playDate: Date? = nil
+    playDate: Date? = nil, persistentID: UInt? = nil
   ) {
     self.artist = artist
     self.album = album
     self.name = name
     self.playCount = playCount
     self.playDate = playDate
+    self.persistentID = persistentID
   }
 
   let artist: String?
@@ -24,6 +25,7 @@ struct Problem: Codable, Hashable {
   let name: String?
   let playCount: Int?
   let playDate: Date?
+  let persistentID: UInt?
 }
 
 struct Fix: Codable {

--- a/Sources/iTunes/Repair/Problem+Criteria.swift
+++ b/Sources/iTunes/Repair/Problem+Criteria.swift
@@ -16,6 +16,7 @@ extension Problem {
     if let name { result.insert(.song(name)) }
     if let playCount { result.insert(.playCount(playCount)) }
     if let playDate { result.insert(.playDate(playDate)) }
+    if let persistentID { result.insert(.persistentId(persistentID)) }
 
     return result
   }

--- a/Sources/iTunes/Repair/Set+Criterion.swift
+++ b/Sources/iTunes/Repair/Set+Criterion.swift
@@ -16,6 +16,7 @@ extension Set where Element == Criterion {
     static let song = Qualifier(rawValue: 1 << 2)
     static let playCount = Qualifier(rawValue: 1 << 3)
     static let playDate = Qualifier(rawValue: 1 << 4)
+    static let persistentID = Qualifier(rawValue: 1 << 5)
 
     static let albumArtistSong: Qualifier = [.album, .artist, .song]
     static let artistSong: Qualifier = [.artist, .song]
@@ -38,13 +39,15 @@ extension Set where Element == Criterion {
         partialResult.insert(.playCount)
       case .playDate(_):
         partialResult.insert(.playDate)
+      case .persistentId(_):
+        partialResult.insert(.persistentID)
       }
     }
   }
 
   var validForIgnore: Bool {
     let qualifiers = qualifiers
-    return qualifiers == .artist || qualifiers == .song
+    return qualifiers == .artist || qualifiers == .song || qualifiers == .persistentID
   }
 
   var validForSortArtist: Bool {

--- a/Sources/iTunes/Repair/Track+Issue.swift
+++ b/Sources/iTunes/Repair/Track+Issue.swift
@@ -24,6 +24,8 @@ extension Track {
       guard let playDateUTC else { return false }
       let timeInterval = abs(playDateUTC.timeIntervalSince1970 - date.timeIntervalSince1970)
       return timeInterval == 0 || timeInterval == 60 * 60
+    case .persistentId(let uint):
+      return persistentID == uint
     }
   }
 

--- a/Tests/iTunes/CriterionTrackApplicableTests.swift
+++ b/Tests/iTunes/CriterionTrackApplicableTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class CriterionTrackApplicableTests: XCTestCase {
   let h = CriterionVariantHelper(
     album: "l", artist: "a", song: "s", playCount: 3,
-    playDate: Date(timeIntervalSince1970: Double(1_075_937_542)))
+    playDate: Date(timeIntervalSince1970: Double(1_075_937_542)), persistentID: 123456)
 
   func testSong() throws {
     let t = Track(name: h.song, persistentID: 0)
@@ -22,6 +22,7 @@ final class CriterionTrackApplicableTests: XCTestCase {
     XCTAssertTrue(t.criteriaApplies(h.songCriterion))
     XCTAssertFalse(t.criteriaApplies(h.playCountCriterion))
     XCTAssertFalse(t.criteriaApplies(h.playDateCriterion))
+    XCTAssertFalse(t.criteriaApplies(h.persistentIDCriterion))
     XCTAssertFalse(t.criteriaApplies(h.albumPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.artistPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.songPlayDateCriterion))
@@ -59,6 +60,7 @@ final class CriterionTrackApplicableTests: XCTestCase {
     XCTAssertTrue(t.criteriaApplies(h.songCriterion))
     XCTAssertFalse(t.criteriaApplies(h.playCountCriterion))
     XCTAssertFalse(t.criteriaApplies(h.playDateCriterion))
+    XCTAssertFalse(t.criteriaApplies(h.persistentIDCriterion))
     XCTAssertFalse(t.criteriaApplies(h.albumPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.artistPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.songPlayDateCriterion))
@@ -96,6 +98,7 @@ final class CriterionTrackApplicableTests: XCTestCase {
     XCTAssertTrue(t.criteriaApplies(h.songCriterion))
     XCTAssertFalse(t.criteriaApplies(h.playCountCriterion))
     XCTAssertFalse(t.criteriaApplies(h.playDateCriterion))
+    XCTAssertFalse(t.criteriaApplies(h.persistentIDCriterion))
     XCTAssertFalse(t.criteriaApplies(h.albumPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.artistPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.songPlayDateCriterion))
@@ -134,6 +137,7 @@ final class CriterionTrackApplicableTests: XCTestCase {
     XCTAssertTrue(t.criteriaApplies(h.songCriterion))
     XCTAssertTrue(t.criteriaApplies(h.playCountCriterion))
     XCTAssertFalse(t.criteriaApplies(h.playDateCriterion))
+    XCTAssertFalse(t.criteriaApplies(h.persistentIDCriterion))
     XCTAssertFalse(t.criteriaApplies(h.albumPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.artistPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.songPlayDateCriterion))
@@ -173,6 +177,7 @@ final class CriterionTrackApplicableTests: XCTestCase {
     XCTAssertTrue(t.criteriaApplies(h.songCriterion))
     XCTAssertTrue(t.criteriaApplies(h.playCountCriterion))
     XCTAssertTrue(t.criteriaApplies(h.playDateCriterion))
+    XCTAssertFalse(t.criteriaApplies(h.persistentIDCriterion))
     XCTAssertTrue(t.criteriaApplies(h.albumPlayDateCriterion))
     XCTAssertTrue(t.criteriaApplies(h.artistPlayDateCriterion))
     XCTAssertTrue(t.criteriaApplies(h.songPlayDateCriterion))
@@ -212,6 +217,7 @@ final class CriterionTrackApplicableTests: XCTestCase {
     XCTAssertTrue(t.criteriaApplies(h.songCriterion))
     XCTAssertTrue(t.criteriaApplies(h.playCountCriterion))
     XCTAssertTrue(t.criteriaApplies(h.playDateCriterion))
+    XCTAssertFalse(t.criteriaApplies(h.persistentIDCriterion))
     XCTAssertTrue(t.criteriaApplies(h.albumPlayDateCriterion))
     XCTAssertTrue(t.criteriaApplies(h.artistPlayDateCriterion))
     XCTAssertTrue(t.criteriaApplies(h.songPlayDateCriterion))
@@ -251,6 +257,7 @@ final class CriterionTrackApplicableTests: XCTestCase {
     XCTAssertTrue(t.criteriaApplies(h.songCriterion))
     XCTAssertTrue(t.criteriaApplies(h.playCountCriterion))
     XCTAssertFalse(t.criteriaApplies(h.playDateCriterion))
+    XCTAssertFalse(t.criteriaApplies(h.persistentIDCriterion))
     XCTAssertFalse(t.criteriaApplies(h.albumPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.artistPlayDateCriterion))
     XCTAssertFalse(t.criteriaApplies(h.songPlayDateCriterion))
@@ -284,5 +291,11 @@ final class CriterionTrackApplicableTests: XCTestCase {
     let t = Track(name: h.song, persistentID: 0)
 
     XCTAssertTrue(t.criteriaApplies([.playCount(0)]))
+  }
+
+  func testPersistentID() throws {
+    let t = Track(name: h.song, persistentID: 123456)
+
+    XCTAssertTrue(t.criteriaApplies(h.persistentIDCriterion))
   }
 }

--- a/Tests/iTunes/CriterionVariantHelper.swift
+++ b/Tests/iTunes/CriterionVariantHelper.swift
@@ -15,6 +15,7 @@ struct CriterionVariantHelper {
   let song: String
   let playCount: Int
   let playDate: Date
+  let persistentID: UInt
 
   var albumCriterion: Set<Criterion> {
     [.album(album)]
@@ -34,6 +35,10 @@ struct CriterionVariantHelper {
 
   var playDateCriterion: Set<Criterion> {
     [.playDate(playDate)]
+  }
+
+  var persistentIDCriterion: Set<Criterion> {
+    [.persistentId(persistentID)]
   }
 
   var albumPlayDateCriterion: Set<Criterion> {

--- a/Tests/iTunes/ProblemCriteriaTests.swift
+++ b/Tests/iTunes/ProblemCriteriaTests.swift
@@ -32,6 +32,7 @@ final class ProblemCriteriaTests: XCTestCase {
     XCTAssertTrue(c.filter { $0.matchesSong("a") }.isEmpty)
     XCTAssertTrue(c.filter { $0.matchesPlayCount(3) }.isEmpty)
     XCTAssertTrue(c.filter { $0.matchesPlayDate(playDate) }.isEmpty)
+    XCTAssertTrue(c.filter { $0.matchesPersistentId(123456) }.isEmpty)
   }
 
   func testAlbum() throws {
@@ -44,6 +45,7 @@ final class ProblemCriteriaTests: XCTestCase {
     XCTAssertTrue(c.filter { $0.matchesSong("a") }.isEmpty)
     XCTAssertTrue(c.filter { $0.matchesPlayCount(3) }.isEmpty)
     XCTAssertTrue(c.filter { $0.matchesPlayDate(playDate) }.isEmpty)
+    XCTAssertTrue(c.filter { $0.matchesPersistentId(123456) }.isEmpty)
   }
 
   func testName() throws {
@@ -56,6 +58,7 @@ final class ProblemCriteriaTests: XCTestCase {
     XCTAssertTrue(!c.filter { $0.matchesSong("a") }.isEmpty)
     XCTAssertTrue(c.filter { $0.matchesPlayCount(3) }.isEmpty)
     XCTAssertTrue(c.filter { $0.matchesPlayDate(playDate) }.isEmpty)
+    XCTAssertTrue(c.filter { $0.matchesPersistentId(123456) }.isEmpty)
   }
 
   func testPlayCount() throws {
@@ -68,6 +71,7 @@ final class ProblemCriteriaTests: XCTestCase {
     XCTAssertTrue(c.filter { $0.matchesSong("a") }.isEmpty)
     XCTAssertTrue(!c.filter { $0.matchesPlayCount(3) }.isEmpty)
     XCTAssertTrue(c.filter { $0.matchesPlayDate(playDate) }.isEmpty)
+    XCTAssertTrue(c.filter { $0.matchesPersistentId(123456) }.isEmpty)
   }
 
   func testPlayDate() throws {
@@ -80,18 +84,34 @@ final class ProblemCriteriaTests: XCTestCase {
     XCTAssertTrue(c.filter { $0.matchesSong("a") }.isEmpty)
     XCTAssertTrue(c.filter { $0.matchesPlayCount(3) }.isEmpty)
     XCTAssertTrue(!c.filter { $0.matchesPlayDate(playDate) }.isEmpty)
+    XCTAssertTrue(c.filter { $0.matchesPersistentId(123456) }.isEmpty)
+  }
+
+  func testPersistentID() throws {
+    let p = Problem(persistentID: 123456)
+    let c = p.criteria
+
+    XCTAssertEqual(c.count, 1)
+    XCTAssertTrue(c.filter { $0.matchesAlbum("a") }.isEmpty)
+    XCTAssertTrue(c.filter { $0.matchesArtist("a") }.isEmpty)
+    XCTAssertTrue(c.filter { $0.matchesSong("a") }.isEmpty)
+    XCTAssertTrue(c.filter { $0.matchesPlayCount(3) }.isEmpty)
+    XCTAssertTrue(c.filter { $0.matchesPlayDate(playDate) }.isEmpty)
+    XCTAssertTrue(!c.filter { $0.matchesPersistentId(123456) }.isEmpty)
   }
 
   func testAllSet() throws {
-    let p = Problem(artist: "a", album: "l", name: "n", playCount: 3, playDate: playDate)
+    let p = Problem(
+      artist: "a", album: "l", name: "n", playCount: 3, playDate: playDate, persistentID: 123456)
 
     let c = p.criteria
 
-    XCTAssertEqual(c.count, 5)
+    XCTAssertEqual(c.count, 6)
     XCTAssertTrue(!c.filter { $0.matchesAlbum("l") }.isEmpty)
     XCTAssertTrue(!c.filter { $0.matchesArtist("a") }.isEmpty)
     XCTAssertTrue(!c.filter { $0.matchesSong("n") }.isEmpty)
     XCTAssertTrue(!c.filter { $0.matchesPlayCount(3) }.isEmpty)
     XCTAssertTrue(!c.filter { $0.matchesPlayDate(playDate) }.isEmpty)
+    XCTAssertTrue(!c.filter { $0.matchesPersistentId(123456) }.isEmpty)
   }
 }

--- a/Tests/iTunes/RemedyCriteriaValidationTests.swift
+++ b/Tests/iTunes/RemedyCriteriaValidationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class RemedyCriteriaValidationTests: XCTestCase {
   let h = CriterionVariantHelper(
     album: "l", artist: "a", song: "s", playCount: 3,
-    playDate: Date(timeIntervalSince1970: Double(1_075_937_542)))
+    playDate: Date(timeIntervalSince1970: Double(1_075_937_542)), persistentID: 123456)
 
   func testIgnore() throws {
     let r = Remedy.ignore
@@ -22,6 +22,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertTrue(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertTrue(r.validate(h.persistentIDCriterion))
     XCTAssertFalse(r.validate(h.albumPlayDateCriterion))
     XCTAssertFalse(r.validate(h.artistPlayDateCriterion))
     XCTAssertFalse(r.validate(h.songPlayDateCriterion))
@@ -59,6 +60,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertTrue(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertFalse(r.validate(h.persistentIDCriterion))
     XCTAssertFalse(r.validate(h.albumPlayDateCriterion))
     XCTAssertTrue(r.validate(h.artistPlayDateCriterion))
     XCTAssertTrue(r.validate(h.songPlayDateCriterion))
@@ -96,6 +98,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertFalse(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertFalse(r.validate(h.persistentIDCriterion))
     XCTAssertFalse(r.validate(h.albumPlayDateCriterion))
     XCTAssertFalse(r.validate(h.artistPlayDateCriterion))
     XCTAssertFalse(r.validate(h.songPlayDateCriterion))
@@ -133,6 +136,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertFalse(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertFalse(r.validate(h.persistentIDCriterion))
     XCTAssertFalse(r.validate(h.albumPlayDateCriterion))
     XCTAssertFalse(r.validate(h.artistPlayDateCriterion))
     XCTAssertFalse(r.validate(h.songPlayDateCriterion))
@@ -170,6 +174,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertFalse(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertFalse(r.validate(h.persistentIDCriterion))
     XCTAssertTrue(r.validate(h.albumPlayDateCriterion))
     XCTAssertTrue(r.validate(h.artistPlayDateCriterion))
     XCTAssertFalse(r.validate(h.songPlayDateCriterion))
@@ -207,6 +212,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertFalse(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertFalse(r.validate(h.persistentIDCriterion))
     XCTAssertFalse(r.validate(h.albumPlayDateCriterion))
     XCTAssertFalse(r.validate(h.artistPlayDateCriterion))
     XCTAssertFalse(r.validate(h.songPlayDateCriterion))
@@ -244,6 +250,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertFalse(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertFalse(r.validate(h.persistentIDCriterion))
     XCTAssertTrue(r.validate(h.albumPlayDateCriterion))
     XCTAssertFalse(r.validate(h.artistPlayDateCriterion))
     XCTAssertFalse(r.validate(h.songPlayDateCriterion))
@@ -281,6 +288,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertTrue(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertFalse(r.validate(h.persistentIDCriterion))
     XCTAssertFalse(r.validate(h.albumPlayDateCriterion))
     XCTAssertTrue(r.validate(h.artistPlayDateCriterion))
     XCTAssertTrue(r.validate(h.songPlayDateCriterion))
@@ -318,6 +326,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertFalse(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertFalse(r.validate(h.persistentIDCriterion))
     XCTAssertFalse(r.validate(h.albumPlayDateCriterion))
     XCTAssertFalse(r.validate(h.artistPlayDateCriterion))
     XCTAssertFalse(r.validate(h.songPlayDateCriterion))
@@ -355,6 +364,7 @@ final class RemedyCriteriaValidationTests: XCTestCase {
     XCTAssertFalse(r.validate(h.songCriterion))
     XCTAssertFalse(r.validate(h.playCountCriterion))
     XCTAssertFalse(r.validate(h.playDateCriterion))
+    XCTAssertFalse(r.validate(h.persistentIDCriterion))
     XCTAssertFalse(r.validate(h.albumPlayDateCriterion))
     XCTAssertFalse(r.validate(h.artistPlayDateCriterion))
     XCTAssertFalse(r.validate(h.songPlayDateCriterion))


### PR DESCRIPTION
- Oh Sees - Gholu was Apple Music mis-matched, and thus in the library twice. The only unique thing about it was the persistentID
- Therefore allow Tracks to be ignored by persistentID only.