### PR TITLE
Create Repair Logger on demand

### DIFF
--- a/Sources/iTunes/Logger+Token.swift
+++ b/Sources/iTunes/Logger+Token.swift
@@ -9,7 +9,11 @@ import os
 
 extension Logger {
   public init(type: String, category: String) {
-    let prefix = LoggingToken != nil ? "\(LoggingToken!): " : ""
+    self.init(type: type, category: category, token: LoggingToken)
+  }
+
+  public init(type: String, category: String, token: String?) {
+    let prefix = token != nil ? "\(token!): " : ""
     self.init(subsystem: "\(prefix)\(type)", category: category)
   }
 }

--- a/Sources/iTunes/Repair/Repair+Load.swift
+++ b/Sources/iTunes/Repair/Repair+Load.swift
@@ -8,16 +8,14 @@
 import Foundation
 import os
 
-extension Logger {
-  static let duplicateProblem = Logger(type: "repair", category: "duplicateProblem")
-}
-
 private enum RepairError: Error {
   case invalidInput
   case invalidString
 }
 
-public func createRepair(url: URL?, source: String?) async throws -> Repairing {
+public func createRepair(url: URL?, source: String?, loggingToken: String?) async throws
+  -> Repairing
+{
   var items: [Item]?
   if let url { items = try await load(url: url) }
   if let source { items = try load(source: source) }
@@ -26,9 +24,15 @@ public func createRepair(url: URL?, source: String?) async throws -> Repairing {
       $1.count > 1
     }
     .keys
-    duplicateProblems.forEach {
-      Logger.duplicateProblem.error("\(String(describing: $0), privacy: .public)")
+    if !duplicateProblems.isEmpty {
+      let duplicateProblemLogger = Logger(
+        type: "repair", category: "duplicateProblem", token: loggingToken)
+
+      duplicateProblems.forEach {
+        duplicateProblemLogger.error("\(String(describing: $0), privacy: .public)")
+      }
     }
+
     //      do {
     //        try printRepairJson(items: items)
     //      } catch {}

--- a/Sources/tool/Program.swift
+++ b/Sources/tool/Program.swift
@@ -105,7 +105,9 @@ struct Program: AsyncParsableCommand {
 
     let tracks = try await {
       let repair =
-        isRepairing ? try? await createRepair(url: repairFile, source: repairSource) : nil
+        isRepairing
+        ? try? await createRepair(url: repairFile, source: repairSource, loggingToken: loggingToken)
+        : nil
       let artistIncluded: ((String) -> Bool)? = {
         if let artistNameFilter, !artistNameFilter.isEmpty {
           return { $0 == artistNameFilter }


### PR DESCRIPTION
- removes a global that now no longer hangs around
- passes in loggingToken in a thread safe manner.