### PR TITLE
Add TrackValidation

### DIFF
--- a/Sources/iTunes/Array+TrackRow.swift
+++ b/Sources/iTunes/Array+TrackRow.swift
@@ -9,9 +9,10 @@ import Foundation
 
 extension Array where Element == Track {
   func rowEncoder(_ loggingToken: String?) -> TrackRowEncoder {
-    TrackRowEncoder(
-      rows: self.filter { $0.isSQLEncodable }.map { $0.trackRow(loggingToken) },
-      loggingToken: loggingToken)
+    let validation = TrackValidation(loggingToken: loggingToken)
+    return TrackRowEncoder(
+      rows: self.filter { $0.isSQLEncodable }.map { $0.trackRow(validation) },
+      validation: validation)
   }
 }
 

--- a/Sources/iTunes/RowAlbum.swift
+++ b/Sources/iTunes/RowAlbum.swift
@@ -6,20 +6,23 @@
 //
 
 import Foundation
+import os
 
 protocol RowAlbumInterface {
-  var albumName: SortableName { get }
-  var albumTrackCount: Int { get }
+  func albumName(logger: Logger) -> SortableName
+  func albumTrackCount(logger: Logger) -> Int
   var albumDiscCount: Int { get }
   var albumDiscNumber: Int { get }
   var albumIsCompilation: Int { get }
 }
 
 struct RowAlbum: Hashable {
-  init(_ album: RowAlbumInterface) {
+  init(_ album: RowAlbumInterface, validation: TrackValidation) {
     self.init(
-      name: album.albumName, trackCount: album.albumTrackCount, discCount: album.albumDiscCount,
-      discNumber: album.albumDiscNumber, compilation: album.albumIsCompilation)
+      name: album.albumName(logger: validation.noAlbum),
+      trackCount: album.albumTrackCount(logger: validation.noTrackCount),
+      discCount: album.albumDiscCount, discNumber: album.albumDiscNumber,
+      compilation: album.albumIsCompilation)
   }
 
   init() {

--- a/Sources/iTunes/RowArtist.swift
+++ b/Sources/iTunes/RowArtist.swift
@@ -6,16 +6,17 @@
 //
 
 import Foundation
+import os
 
 protocol RowArtistInterface {
-  var artistName: SortableName { get }
+  func artistName(logger: Logger) -> SortableName
 }
 
 struct RowArtist: Hashable {
   let name: SortableName
 
-  init(_ artist: RowArtistInterface) {
-    self.init(name: artist.artistName)
+  init(_ artist: RowArtistInterface, validation: TrackValidation) {
+    self.init(name: artist.artistName(logger: validation.noArtist))
   }
 
   init() {

--- a/Sources/iTunes/RowPlay.swift
+++ b/Sources/iTunes/RowPlay.swift
@@ -8,12 +8,14 @@
 import Foundation
 
 protocol RowPlayInterface {
-  func songPlayedInformation(_ loggingToken: String?) -> (datePlayedISO8601: String, playCount: Int)
+  func songPlayedInformation(_ validation: TrackValidation) -> (
+    datePlayedISO8601: String, playCount: Int
+  )
 }
 
 struct RowPlay: Hashable {
-  init?(_ play: RowPlayInterface, loggingToken: String?) {
-    let info = play.songPlayedInformation(loggingToken)
+  init?(_ play: RowPlayInterface, validation: TrackValidation) {
+    let info = play.songPlayedInformation(validation)
 
     guard info.playCount > 0 || !info.datePlayedISO8601.isEmpty else { return nil }
 

--- a/Sources/iTunes/RowSong.swift
+++ b/Sources/iTunes/RowSong.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os
 
 protocol RowSongInterface {
   var songPersistentID: UInt { get }
@@ -13,17 +14,18 @@ protocol RowSongInterface {
   var songComments: String { get }
   var dateReleasedISO8601: String { get }
   var songName: SortableName { get }
-  var songTrackNumber: Int { get }
-  var songYear: Int { get }
+  func songTrackNumber(validation: TrackValidation) -> Int
+  func songYear(logger: Logger) -> Int
   var songDuration: Int { get }
   var dateAddedISO8601: String { get }
 }
 
 struct RowSong: Hashable {
-  init(_ song: RowSongInterface) {
+  init(_ song: RowSongInterface, validation: TrackValidation) {
     self.init(
       name: song.songName, itunesid: song.songPersistentID, composer: song.songComposer,
-      trackNumber: song.songTrackNumber, year: song.songYear, duration: song.songDuration,
+      trackNumber: song.songTrackNumber(validation: validation),
+      year: song.songYear(logger: validation.noYear), duration: song.songDuration,
       dateAdded: song.dateAddedISO8601, dateReleased: song.dateReleasedISO8601,
       comments: song.songComments)
   }

--- a/Sources/iTunes/Track+RowAlbum.swift
+++ b/Sources/iTunes/Track+RowAlbum.swift
@@ -8,23 +8,18 @@
 import Foundation
 import os
 
-extension Logger {
-  static let noAlbum = Logger(type: "validation", category: "noAlbum")
-  static let noTrackCount = Logger(type: "validation", category: "noTrackCount")
-}
-
 extension Track: RowAlbumInterface {
-  var albumName: SortableName {
+  func albumName(logger: Logger) -> SortableName {
     guard let album else {
-      Logger.noAlbum.error("\(debugLogInformation, privacy: .public)")
+      logger.error("\(debugLogInformation, privacy: .public)")
       return SortableName()
     }
     return SortableName(name: album, sorted: sortAlbum ?? "")
   }
 
-  var albumTrackCount: Int {
+  func albumTrackCount(logger: Logger) -> Int {
     guard let trackCount else {
-      Logger.noTrackCount.error("\(debugLogInformation, privacy: .public)")
+      logger.error("\(debugLogInformation, privacy: .public)")
       return -1
     }
     return trackCount

--- a/Sources/iTunes/Track+RowArtist.swift
+++ b/Sources/iTunes/Track+RowArtist.swift
@@ -8,14 +8,10 @@
 import Foundation
 import os
 
-extension Logger {
-  static let noArtist = Logger(type: "validation", category: "noArtist")
-}
-
 extension Track: RowArtistInterface {
-  var artistName: SortableName {
+  func artistName(logger: Logger) -> SortableName {
     guard let name = (artist ?? albumArtist ?? nil) else {
-      Logger.noArtist.error("\(debugLogInformation, privacy: .public)")
+      logger.error("\(debugLogInformation, privacy: .public)")
       return SortableName()
     }
     return SortableName(name: name, sorted: (sortArtist ?? sortAlbumArtist) ?? "")

--- a/Sources/iTunes/Track+RowPlay.swift
+++ b/Sources/iTunes/Track+RowPlay.swift
@@ -9,19 +9,18 @@ import Foundation
 import os
 
 extension Track: RowPlayInterface {
-  func songPlayedInformation(_ loggingToken: String?) -> (datePlayedISO8601: String, playCount: Int)
-  {
+  func songPlayedInformation(_ validation: TrackValidation) -> (
+    datePlayedISO8601: String, playCount: Int
+  ) {
     let datePlayed = datePlayedISO8601
     let playCount = songPlayCount
 
     if datePlayed.isEmpty || playCount == 0 {
       if playCount != 0 {
-        Logger(type: "validation", category: "noPlayDate", token: loggingToken).error(
-          "\(debugLogInformation, privacy: .public)")
+        validation.noPlayDate.error("\(debugLogInformation, privacy: .public)")
       }
       if !datePlayed.isEmpty {
-        Logger(type: "validation", category: "noPlayCount", token: loggingToken).error(
-          "\(debugLogInformation, privacy: .public)")
+        validation.noPlayCount.error("\(debugLogInformation, privacy: .public)")
       }
     }
 

--- a/Sources/iTunes/Track+RowSong.swift
+++ b/Sources/iTunes/Track+RowSong.swift
@@ -8,12 +8,6 @@
 import Foundation
 import os
 
-extension Logger {
-  static let noTrackNumber = Logger(type: "validation", category: "noTrackNumber")
-  static let badTrackNumber = Logger(type: "validation", category: "badTrackNumber")
-  static let noYear = Logger(type: "validation", category: "noYear")
-}
-
 extension Track: RowSongInterface {
   var songPersistentID: UInt {
     persistentID

--- a/Sources/iTunes/Track+RowSong.swift
+++ b/Sources/iTunes/Track+RowSong.swift
@@ -36,21 +36,21 @@ extension Track: RowSongInterface {
     SortableName(name: name, sorted: sortName ?? "")
   }
 
-  var songTrackNumber: Int {
+  func songTrackNumber(validation: TrackValidation) -> Int {
     guard let trackNumber else {
-      Logger.noTrackNumber.error("\(debugLogInformation, privacy: .public)")
+      validation.noTrackNumber.error("\(debugLogInformation, privacy: .public)")
       return -1
     }
     guard trackNumber > 0 else {
-      Logger.badTrackNumber.error("\(debugLogInformation, privacy: .public)")
+      validation.badTrackNumber.error("\(debugLogInformation, privacy: .public)")
       return -1
     }
     return trackNumber
   }
 
-  var songYear: Int {
+  func songYear(logger: Logger) -> Int {
     guard let year else {
-      Logger.noYear.error("\(debugLogInformation, privacy: .public)")
+      logger.error("\(debugLogInformation, privacy: .public)")
       return -1
     }
     return year

--- a/Sources/iTunes/Track+TrackRow.swift
+++ b/Sources/iTunes/Track+TrackRow.swift
@@ -8,9 +8,10 @@
 import Foundation
 
 extension Track {
-  func trackRow(_ loggingToken: String?) -> TrackRow {
+  func trackRow(_ validation: TrackValidation) -> TrackRow {
     TrackRow(
-      album: RowAlbum(self), artist: RowArtist(self), song: RowSong(self),
-      play: RowPlay(self, loggingToken: loggingToken))
+      album: RowAlbum(self, validation: validation),
+      artist: RowArtist(self, validation: validation), song: RowSong(self, validation: validation),
+      play: RowPlay(self, validation: validation))
   }
 }

--- a/Sources/iTunes/TrackRowEncoder.swift
+++ b/Sources/iTunes/TrackRowEncoder.swift
@@ -40,17 +40,15 @@ extension TrackRow {
 
 struct TrackRowEncoder {
   let rows: [TrackRow]
-  let loggingToken: String?
+  let validation: TrackValidation
 
   var artistRows: (table: String, rows: [RowArtist]) {
     let artistRows = Array(Set(rows.map { $0.artist }))
 
     let mismatched = artistRows.mismatchedSortableNames
     if !mismatched.isEmpty {
-      let duplicateArtist = Logger(
-        type: "validation", category: "duplicateArtist", token: loggingToken)
       mismatched.forEach {
-        duplicateArtist.error("\($0, privacy: .public)")
+        validation.duplicateArtist.error("\($0, privacy: .public)")
       }
     }
 
@@ -70,10 +68,8 @@ struct TrackRowEncoder {
 
     let duplicates = playRows.duplicatePlayDates
     if !duplicates.isEmpty {
-      let duplicatePlayDate = Logger(
-        type: "validation", category: "duplicatePlayDate", token: loggingToken)
       duplicates.forEach {
-        duplicatePlayDate.error("\($0.debugLogInformation, privacy: .public)")
+        validation.duplicatePlayDate.error("\($0.debugLogInformation, privacy: .public)")
       }
     }
 

--- a/Sources/iTunes/TrackValidation.swift
+++ b/Sources/iTunes/TrackValidation.swift
@@ -1,0 +1,38 @@
+//
+//  TrackValidation.swift
+//
+//
+//  Created by Greg Bolsinga on 3/9/24.
+//
+
+import Foundation
+import os
+
+struct TrackValidation {
+  let noAlbum: Logger
+  let noTrackCount: Logger
+  let noArtist: Logger
+  let noPlayDate: Logger
+  let noPlayCount: Logger
+  let noTrackNumber: Logger
+  let badTrackNumber: Logger
+  let noYear: Logger
+  let duplicateArtist: Logger
+  let duplicatePlayDate: Logger
+
+  init(loggingToken: String?) {
+    self.noAlbum = Logger(type: "validation", category: "noAlbum", token: loggingToken)
+    self.noTrackCount = Logger(type: "validation", category: "noTrackCount", token: loggingToken)
+    self.noArtist = Logger(type: "validation", category: "noArtist", token: loggingToken)
+    self.noPlayDate = Logger(type: "validation", category: "noPlayDate", token: loggingToken)
+    self.noPlayCount = Logger(type: "validation", category: "noPlayCount", token: loggingToken)
+    self.noTrackNumber = Logger(type: "validation", category: "noTrackNumber", token: loggingToken)
+    self.badTrackNumber = Logger(
+      type: "validation", category: "badTrackNumber", token: loggingToken)
+    self.noYear = Logger(type: "validation", category: "noYear", token: loggingToken)
+    self.duplicateArtist = Logger(
+      type: "validation", category: "duplicateArtist", token: loggingToken)
+    self.duplicatePlayDate = Logger(
+      type: "validation", category: "duplicatePlayDate", token: loggingToken)
+  }
+}


### PR DESCRIPTION
- It has Loggers for when validating data for database rows.
- It is passed along to prevent code from having to read from a global, which may have race conditions (warning with strict-concurrenyc enabled).