### PR TITLE
Database has an internal Logging instance

### DIFF
--- a/Sources/iTunes/Array+DB.swift
+++ b/Sources/iTunes/Array+DB.swift
@@ -9,7 +9,8 @@ import Foundation
 
 extension Array where Element == Track {
   public func database(file: URL, loggingToken: String?) async throws {
-    let encoder = try DBEncoder(file: file, rowEncoder: self.rowEncoder(loggingToken))
+    let encoder = try DBEncoder(
+      file: file, rowEncoder: self.rowEncoder(loggingToken), loggingToken: loggingToken)
     try await encoder.encode()
   }
 }

--- a/Sources/iTunes/DBEncoder.swift
+++ b/Sources/iTunes/DBEncoder.swift
@@ -11,8 +11,8 @@ final class DBEncoder {
   private let db: Database
   private let rowEncoder: TrackRowEncoder
 
-  init(file: URL, rowEncoder: TrackRowEncoder) throws {
-    self.db = try Database(file: file)
+  init(file: URL, rowEncoder: TrackRowEncoder, loggingToken: String?) throws {
+    self.db = try Database(file: file, loggingToken: loggingToken)
     self.rowEncoder = rowEncoder
   }
 

--- a/Sources/iTunes/Logger+Token.swift
+++ b/Sources/iTunes/Logger+Token.swift
@@ -8,10 +8,6 @@
 import os
 
 extension Logger {
-  public init(type: String, category: String) {
-    self.init(type: type, category: category, token: LoggingToken)
-  }
-
   public init(type: String, category: String, token: String?) {
     let prefix = token != nil ? "\(token!): " : ""
     self.init(subsystem: "\(prefix)\(type)", category: category)


### PR DESCRIPTION
- This way these are not globals and strict concurrency does not warn.