### PR TITLE
Add String extensions to help out with git tag names

### DIFF
--- a/Sources/iTunes/Destination+GitWriter.swift
+++ b/Sources/iTunes/Destination+GitWriter.swift
@@ -25,7 +25,7 @@ extension Git {
     do {
       try commit(message)
     } catch {
-      tagName = tagName + "-empty"
+      tagName = tagName.emptyTag
     }
     try tag(tagName)
     try push()

--- a/Sources/iTunes/String+GitNames.swift
+++ b/Sources/iTunes/String+GitNames.swift
@@ -1,0 +1,35 @@
+//
+//  String+GitNames.swift
+//
+//
+//  Created by Greg Bolsinga on 4/1/24.
+//
+
+import Foundation
+
+extension String {
+  var emptyTag: String {
+    return self + "-empty"
+  }
+
+  fileprivate func appendValue(_ value: Int) -> String {
+    let formatter = NumberFormatter()
+    formatter.minimumIntegerDigits = 2
+    guard let r = formatter.string(from: value as NSNumber) else { return self }
+    return self + "." + r
+  }
+
+  var nextTag: String {
+    let parts = self.components(separatedBy: ".")
+
+    switch parts.count {
+    case 1:
+      return self.appendValue(1)
+    case 2:
+      guard let index = Int(parts[1]) else { return self }
+      return parts[0].appendValue(index + 1)
+    default:
+      return self
+    }
+  }
+}

--- a/Tests/iTunes/StringGitNameTests.swift
+++ b/Tests/iTunes/StringGitNameTests.swift
@@ -1,0 +1,40 @@
+//
+//  StringGitNameTests.swift
+//
+//
+//  Created by Greg Bolsinga on 4/1/24.
+//
+
+import XCTest
+
+@testable import iTunes
+
+final class StringGitNameTests: XCTestCase {
+  func testEmpty() throws {
+    XCTAssertEqual("name-empty", "name".emptyTag)
+  }
+
+  func testNext_none() throws {
+    XCTAssertEqual("name.01", "name".nextTag)
+  }
+
+  func testNext_incremental() throws {
+    XCTAssertEqual("name.02", "name.1".nextTag)
+  }
+
+  func testNext_incrementalWithLeadingZero() throws {
+    XCTAssertEqual("name.02", "name.01".nextTag)
+  }
+
+  func testNext_notCannonical() throws {
+    XCTAssertEqual("name.it.now", "name.it.now".nextTag)
+  }
+
+  func testNext_notCannonicalIntegral() throws {
+    XCTAssertEqual("name.it.1", "name.it.1".nextTag)
+  }
+
+  func testNext_notIntegral() throws {
+    XCTAssertEqual("name.it", "name.it".nextTag)
+  }
+}


### PR DESCRIPTION
- String.nextTag will be used if there are two identical tags (which are just Dates), and the commit is different.