### PR TITLE
Improve handling duplicate runs of a git commit with the same base backup name

### DIFF
--- a/Sources/iTunes/Git.swift
+++ b/Sources/iTunes/Git.swift
@@ -16,6 +16,8 @@ enum GitError: Error {
   case push(Int32)
   case pushTags(Int32)
   case gc(Int32)
+  case diff(Int32)
+  case contains(Int32)
 }
 
 extension Process {
@@ -86,5 +88,13 @@ struct Git {
 
   func gc() throws {
     try git(["gc", "--prune=now"]) { GitError.gc($0) }
+  }
+
+  func diff() throws {
+    try git(["diff", "--staged", "--name-only", "--exit-code"]) { GitError.diff($0) }
+  }
+
+  func tagContains(_ message: String) throws -> [String] {
+    try git(["tag", "--contains", message]) { GitError.contains($0) }
   }
 }

--- a/Sources/iTunes/GitBackup.swift
+++ b/Sources/iTunes/GitBackup.swift
@@ -1,0 +1,31 @@
+//
+//  GitBackup.swift
+//
+//
+//  Created by Greg Bolsinga on 4/2/24.
+//
+
+import Foundation
+
+enum GitBackup {
+  case noChanges
+  case changes
+}
+
+extension GitBackup {
+  fileprivate func calculateBackupName(baseName: String, existingNames: [String]) -> String {
+    let existingBaseNames = existingNames.filter { $0.starts(with: baseName) }.sorted().reversed()
+    guard !existingBaseNames.isEmpty else { return baseName }
+    return existingBaseNames.first!.nextTag
+  }
+
+  func backupName(baseName: String, existingNames: [String]) -> String {
+    let backupName = calculateBackupName(baseName: baseName, existingNames: existingNames)
+    switch self {
+    case .noChanges:
+      return backupName.emptyTag
+    case .changes:
+      return backupName
+    }
+  }
+}

--- a/Tests/iTunes/GitBackupNameTests.swift
+++ b/Tests/iTunes/GitBackupNameTests.swift
@@ -1,0 +1,77 @@
+//
+//  GitBackupNameTests.swift
+//
+//
+//  Created by Greg Bolsinga on 4/2/24.
+//
+
+import XCTest
+
+@testable import iTunes
+
+let PreviousName = "A"
+let BasicName = "B"
+let SubsequentName = "C"
+
+final class GitBackupNameTests: XCTestCase {
+  func test_noExisting() throws {
+    XCTAssertEqual(
+      "B-empty", GitBackup.noChanges.backupName(baseName: BasicName, existingNames: []))
+    XCTAssertEqual("B", GitBackup.changes.backupName(baseName: BasicName, existingNames: []))
+  }
+
+  func testNoChanges_oneExisting() throws {
+    XCTAssertEqual(
+      "B.01-empty", GitBackup.noChanges.backupName(baseName: BasicName, existingNames: [BasicName]))
+    XCTAssertEqual(
+      "B.02-empty",
+      GitBackup.noChanges.backupName(baseName: BasicName, existingNames: ["\(BasicName).01"]))
+    XCTAssertEqual(
+      "B-empty", GitBackup.noChanges.backupName(baseName: BasicName, existingNames: [PreviousName]))
+  }
+
+  func testChanges_oneExisting() throws {
+    XCTAssertEqual(
+      "B.01", GitBackup.changes.backupName(baseName: BasicName, existingNames: [BasicName]))
+    XCTAssertEqual(
+      "B.02", GitBackup.changes.backupName(baseName: BasicName, existingNames: ["\(BasicName).01"]))
+    XCTAssertEqual(
+      "B", GitBackup.changes.backupName(baseName: BasicName, existingNames: [PreviousName]))
+  }
+
+  func testNoChanges_multipleExisting() throws {
+    XCTAssertEqual(
+      "B.01-empty",
+      GitBackup.noChanges.backupName(baseName: BasicName, existingNames: [PreviousName, BasicName]))
+    XCTAssertEqual(
+      "B.02-empty",
+      GitBackup.noChanges.backupName(
+        baseName: BasicName, existingNames: [PreviousName, BasicName, "\(BasicName).01"]))
+    XCTAssertEqual(
+      "B-empty",
+      GitBackup.noChanges.backupName(
+        baseName: BasicName, existingNames: [PreviousName, SubsequentName]))
+    XCTAssertEqual(
+      "B.01-empty",
+      GitBackup.noChanges.backupName(
+        baseName: BasicName, existingNames: [PreviousName, BasicName, SubsequentName]))
+  }
+
+  func testChanges_multipleExisting() throws {
+    XCTAssertEqual(
+      "B.01",
+      GitBackup.changes.backupName(baseName: BasicName, existingNames: [PreviousName, BasicName]))
+    XCTAssertEqual(
+      "B.02",
+      GitBackup.changes.backupName(
+        baseName: BasicName, existingNames: [PreviousName, BasicName, "\(BasicName).01"]))
+    XCTAssertEqual(
+      "B",
+      GitBackup.changes.backupName(
+        baseName: BasicName, existingNames: [PreviousName, SubsequentName]))
+    XCTAssertEqual(
+      "B.01",
+      GitBackup.changes.backupName(
+        baseName: BasicName, existingNames: [PreviousName, BasicName, SubsequentName]))
+  }
+}


### PR DESCRIPTION
- This way if the program runs a few times a day, it will handle each situation.
- If nothing has changed, the git tag with be "<name>-empty". If something has changed, but the basename is the same (since it is the same for each calendar day) it will be "<name>.01", "name.02" etc. Those names can be "<name>.01-empty" as well if that happens.

This is mostly because if the mac reboots and the LaunchAgent has the `RunAtLoad` key it will run at each reboot. In the old way, it will just re-write the same json.gz file over (but with any new data). This will not overwrite any data, and will not throw an error, causing the backup to fail.

This work and https://github.com/bolsinga/bin_utils/pull/43 should address https://github.com/bolsinga/bin_utils/issues/34