### PR TITLE
Explictly close the DBEnoder and its Database.

### DIFF
--- a/Sources/iTunes/Array+DB.swift
+++ b/Sources/iTunes/Array+DB.swift
@@ -11,7 +11,12 @@ extension Array where Element == Track {
   public func database(file: URL, loggingToken: String?) async throws {
     let encoder = try DBEncoder(
       file: file, rowEncoder: self.rowEncoder(loggingToken), loggingToken: loggingToken)
-    try await encoder.encode()
-    await encoder.close()
+    do {
+      try await encoder.encode()
+      await encoder.close()
+    } catch {
+      await encoder.close()
+      throw error
+    }
   }
 }

--- a/Sources/iTunes/Array+DB.swift
+++ b/Sources/iTunes/Array+DB.swift
@@ -12,5 +12,6 @@ extension Array where Element == Track {
     let encoder = try DBEncoder(
       file: file, rowEncoder: self.rowEncoder(loggingToken), loggingToken: loggingToken)
     try await encoder.encode()
+    await encoder.close()
   }
 }

--- a/Sources/iTunes/Array+DB.swift
+++ b/Sources/iTunes/Array+DB.swift
@@ -9,13 +9,14 @@ import Foundation
 
 extension Array where Element == Track {
   public func database(file: URL, loggingToken: String?) async throws {
-    let encoder = try DBEncoder(
-      file: file, rowEncoder: self.rowEncoder(loggingToken), loggingToken: loggingToken)
+    var encoder: DBEncoder?
     do {
-      try await encoder.encode()
-      await encoder.close()
+      encoder = try DBEncoder(
+        file: file, rowEncoder: self.rowEncoder(loggingToken), loggingToken: loggingToken)
+      try await encoder?.encode()
+      await encoder?.close()
     } catch {
-      await encoder.close()
+      await encoder?.close()
       throw error
     }
   }

--- a/Sources/iTunes/DBEncoder.swift
+++ b/Sources/iTunes/DBEncoder.swift
@@ -69,4 +69,8 @@ final class DBEncoder {
     try await emitPlays(songLookup: songLookup)
     try await db.execute(rowEncoder.views)
   }
+
+  func close() async {
+    await db.close()
+  }
 }

--- a/Sources/iTunes/Database.swift
+++ b/Sources/iTunes/Database.swift
@@ -153,7 +153,7 @@ actor Database {
     }
   }
 
-  deinit {
+  func close() {
     statements.values.forEach { $0.close() }
     let result = sqlite3_close(handle)
     logging.close.log("\(result, privacy: .public)")


### PR DESCRIPTION
- Removes warnings like:
```
Cannot access property 'statements' with a non-sendable type '[String : Database.Statement]' from non-isolated deinit; this is an error in Swift 6
```
- Work towards #329 