### PR TITLE
Statement.bind() takes an ErrorStringBuilder

### DIFF
--- a/Sources/iTunes/DBEncoder.swift
+++ b/Sources/iTunes/DBEncoder.swift
@@ -32,7 +32,7 @@ final class DBEncoder {
 
       var lookup = [T: Int64](minimumCapacity: rows.count)
       for (row, ids) in zip(rows, ids) {
-        try row.bindInsert(db: db, statement: statement, ids: ids)
+        try row.bindInsert(statement: statement, ids: ids, errorStringBuilder: errorStringBuilder)
         try statement.execute(errorStringBuilder)
         lookup[row] = db.lastID
       }

--- a/Sources/iTunes/Database.swift
+++ b/Sources/iTunes/Database.swift
@@ -99,12 +99,12 @@ actor Database {
       logging.finalize.log("\(result, privacy: .public)")
     }
 
-    func bind(db: Database, count: Int32, binder: (Int32) -> Value) throws {
+    func bind(count: Int32, binder: (Int32) -> Value, errorStringBuilder: () -> String) throws {
       do {
         for index in 1...count {
           let value = binder(index)
           try value.bind(
-            statementHandle: handle, index: index, errorStringBuilder: { db.handle.sqlError })
+            statementHandle: handle, index: index, errorStringBuilder: errorStringBuilder)
         }
       } catch {
         logging.bind.error("\(error.localizedDescription, privacy: .public)")

--- a/Sources/iTunes/RowAlbum+SQLBindableInsert.swift
+++ b/Sources/iTunes/RowAlbum+SQLBindableInsert.swift
@@ -12,26 +12,30 @@ extension RowAlbum: SQLBindableInsert {
     Self.bound { RowAlbum().insert }
   }
 
-  func bindInsert(db: Database, statement: Database.Statement, ids: [Int64]) throws {
+  func bindInsert(statement: Database.Statement, ids: [Int64], errorStringBuilder: () -> String)
+    throws
+  {
     guard ids.isEmpty else { throw SQLBindingError.noIDsRequired }
 
-    try statement.bind(db: db, count: 6) { index in
-      switch index {
-      case 1:
-        Database.Value.string(name.name)
-      case 2:
-        Database.Value.string(name.sorted)
-      case 3:
-        Database.Value.integer(Int64(trackCount))
-      case 4:
-        Database.Value.integer(Int64(discCount))
-      case 5:
-        Database.Value.integer(Int64(discNumber))
-      case 6:
-        Database.Value.integer(Int64(compilation))
-      default:
-        preconditionFailure()
-      }
-    }
+    try statement.bind(
+      count: 6,
+      binder: { index in
+        switch index {
+        case 1:
+          Database.Value.string(name.name)
+        case 2:
+          Database.Value.string(name.sorted)
+        case 3:
+          Database.Value.integer(Int64(trackCount))
+        case 4:
+          Database.Value.integer(Int64(discCount))
+        case 5:
+          Database.Value.integer(Int64(discNumber))
+        case 6:
+          Database.Value.integer(Int64(compilation))
+        default:
+          preconditionFailure()
+        }
+      }, errorStringBuilder: errorStringBuilder)
   }
 }

--- a/Sources/iTunes/RowArtist+SQLBindableInsert.swift
+++ b/Sources/iTunes/RowArtist+SQLBindableInsert.swift
@@ -10,18 +10,22 @@ import Foundation
 extension RowArtist: SQLBindableInsert {
   static var insertBinding: String { Self.bound { RowArtist().insert } }
 
-  func bindInsert(db: Database, statement: Database.Statement, ids: [Int64]) throws {
+  func bindInsert(statement: Database.Statement, ids: [Int64], errorStringBuilder: () -> String)
+    throws
+  {
     guard ids.isEmpty else { throw SQLBindingError.noIDsRequired }
 
-    try statement.bind(db: db, count: 2) { index in
-      switch index {
-      case 1:
-        Database.Value.string(name.name)
-      case 2:
-        Database.Value.string(name.sorted)
-      default:
-        preconditionFailure()
-      }
-    }
+    try statement.bind(
+      count: 2,
+      binder: { index in
+        switch index {
+        case 1:
+          Database.Value.string(name.name)
+        case 2:
+          Database.Value.string(name.sorted)
+        default:
+          preconditionFailure()
+        }
+      }, errorStringBuilder: errorStringBuilder)
   }
 }

--- a/Sources/iTunes/RowPlay+SQLBindableInsert.swift
+++ b/Sources/iTunes/RowPlay+SQLBindableInsert.swift
@@ -12,20 +12,24 @@ extension RowPlay: SQLBindableInsert {
     Self.bound { RowPlay().insert(songid: "") }
   }
 
-  func bindInsert(db: Database, statement: Database.Statement, ids: [Int64]) throws {
+  func bindInsert(statement: Database.Statement, ids: [Int64], errorStringBuilder: () -> String)
+    throws
+  {
     guard ids.count == 1 else { throw SQLBindingError.iDsRequired }
 
-    try statement.bind(db: db, count: 3) { index in
-      switch index {
-      case 1:
-        Database.Value.string(date)
-      case 2:
-        Database.Value.integer(Int64(delta))
-      case 3:
-        Database.Value.integer(ids[0])
-      default:
-        preconditionFailure()
-      }
-    }
+    try statement.bind(
+      count: 3,
+      binder: { index in
+        switch index {
+        case 1:
+          Database.Value.string(date)
+        case 2:
+          Database.Value.integer(Int64(delta))
+        case 3:
+          Database.Value.integer(ids[0])
+        default:
+          preconditionFailure()
+        }
+      }, errorStringBuilder: errorStringBuilder)
   }
 }

--- a/Sources/iTunes/RowSong+SQLBindableInsert.swift
+++ b/Sources/iTunes/RowSong+SQLBindableInsert.swift
@@ -12,38 +12,42 @@ extension RowSong: SQLBindableInsert {
     Self.bound { RowSong().insert(artistID: "", albumID: "") }
   }
 
-  func bindInsert(db: Database, statement: Database.Statement, ids: [Int64]) throws {
+  func bindInsert(statement: Database.Statement, ids: [Int64], errorStringBuilder: () -> String)
+    throws
+  {
     guard ids.count == 2 else { throw SQLBindingError.iDsRequired }
 
-    try statement.bind(db: db, count: 12) { index in
-      switch index {
-      case 1:
-        Database.Value.string(name.name)
-      case 2:
-        Database.Value.string(name.sorted)
-      case 3:
-        Database.Value.string(String(itunesid))
-      case 4:
-        Database.Value.string(String(composer))
-      case 5:
-        Database.Value.integer(Int64(trackNumber))
-      case 6:
-        Database.Value.integer(Int64(year))
-      case 7:
-        Database.Value.integer(Int64(duration))
-      case 8:
-        Database.Value.string(dateAdded)
-      case 9:
-        Database.Value.string(dateReleased)
-      case 10:
-        Database.Value.string(comments)
-      case 11:
-        Database.Value.integer(ids[0])
-      case 12:
-        Database.Value.integer(ids[1])
-      default:
-        preconditionFailure()
-      }
-    }
+    try statement.bind(
+      count: 12,
+      binder: { index in
+        switch index {
+        case 1:
+          Database.Value.string(name.name)
+        case 2:
+          Database.Value.string(name.sorted)
+        case 3:
+          Database.Value.string(String(itunesid))
+        case 4:
+          Database.Value.string(String(composer))
+        case 5:
+          Database.Value.integer(Int64(trackNumber))
+        case 6:
+          Database.Value.integer(Int64(year))
+        case 7:
+          Database.Value.integer(Int64(duration))
+        case 8:
+          Database.Value.string(dateAdded)
+        case 9:
+          Database.Value.string(dateReleased)
+        case 10:
+          Database.Value.string(comments)
+        case 11:
+          Database.Value.integer(ids[0])
+        case 12:
+          Database.Value.integer(ids[1])
+        default:
+          preconditionFailure()
+        }
+      }, errorStringBuilder: errorStringBuilder)
   }
 }

--- a/Sources/iTunes/SQLBindableStatement.swift
+++ b/Sources/iTunes/SQLBindableStatement.swift
@@ -26,5 +26,6 @@ enum SQLBindingError: Error {
 protocol SQLBindableInsert: SQLBindableStatement {
   static var insertBinding: String { get }
 
-  func bindInsert(db: Database, statement: Database.Statement, ids: [Int64]) throws
+  func bindInsert(statement: Database.Statement, ids: [Int64], errorStringBuilder: () -> String)
+    throws
 }


### PR DESCRIPTION
This removes the last StrictConcurrency warning about the Database `OpaquePointer`. Fixes #331