### PR TITLE
Simplify SQL string interpolation

### DIFF
--- a/Sources/iTunes/RowAlbum.swift
+++ b/Sources/iTunes/RowAlbum.swift
@@ -46,10 +46,10 @@ struct RowAlbum: Hashable, Sendable {
   let compilation: Int
 
   var selectID: String {
-    "(SELECT id FROM albums WHERE name = \(sql: name.name, options:.safeQuoted) AND trackcount = \(sql: trackCount) AND disccount = \(sql: discCount) AND discnumber = \(sql: discNumber) AND compilation = \(sql: compilation))"
+    "(SELECT id FROM albums WHERE name = \(sql: name.name, options:.quoteEscaped) AND trackcount = \(sql: trackCount) AND disccount = \(sql: discCount) AND discnumber = \(sql: discNumber) AND compilation = \(sql: compilation))"
   }
 
   var insert: String {
-    "INSERT INTO albums (name, sortname, trackcount, disccount, discnumber, compilation) VALUES (\(sql: name.name, options:.safeQuoted), \(sql: name.sorted, options:.safeQuoted), \(sql: trackCount), \(sql: discCount), \(sql: discNumber), \(sql: compilation));"
+    "INSERT INTO albums (name, sortname, trackcount, disccount, discnumber, compilation) VALUES (\(sql: name.name, options:.quoteEscaped), \(sql: name.sorted, options:.quoteEscaped), \(sql: trackCount), \(sql: discCount), \(sql: discNumber), \(sql: compilation));"
   }
 }

--- a/Sources/iTunes/RowArtist.swift
+++ b/Sources/iTunes/RowArtist.swift
@@ -32,10 +32,10 @@ struct RowArtist: Hashable, Sendable {
   }
 
   var selectID: String {
-    "(SELECT id FROM artists WHERE name = \(sql: name.name, options:.safeQuoted))"
+    "(SELECT id FROM artists WHERE name = \(sql: name.name, options:.quoteEscaped))"
   }
 
   var insert: String {
-    "INSERT INTO artists (name, sortname) VALUES (\(sql: name.name, options:.safeQuoted), \(sql: name.sorted, options:.safeQuoted));"
+    "INSERT INTO artists (name, sortname) VALUES (\(sql: name.name, options:.quoteEscaped), \(sql: name.sorted, options:.quoteEscaped));"
   }
 }

--- a/Sources/iTunes/RowPlay.swift
+++ b/Sources/iTunes/RowPlay.swift
@@ -35,6 +35,6 @@ struct RowPlay: Hashable, Sendable {
   let delta: Int
 
   func insert(songid: String) -> String {
-    "INSERT INTO plays (date, delta, songid) VALUES (\(sql: date, options:.quoted), \(sql: delta), \(sql: songid));"
+    "INSERT INTO plays (date, delta, songid) VALUES (\(sql: date, options:.quoteEscaped), \(sql: delta), \(sql: songid));"
   }
 }

--- a/Sources/iTunes/RowSong.swift
+++ b/Sources/iTunes/RowSong.swift
@@ -62,10 +62,10 @@ struct RowSong: Hashable, Sendable {
   let comments: String
 
   func selectID(artistID: String, albumID: String) -> String {
-    "(SELECT id FROM songs WHERE name = \(sql: name.name, options:.safeQuoted) AND itunesid = \(sql: itunesid, options: .quoted) AND artistid = \(sql: artistID) AND albumid = \(sql: albumID) AND tracknumber = \(sql: trackNumber) AND year = \(sql: year) AND duration = \(sql: duration) AND dateadded = \(sql: dateAdded, options: .quoted))"
+    "(SELECT id FROM songs WHERE name = \(sql: name.name, options:.quoteEscaped) AND itunesid = \(sql: itunesid, options: .quoteEscaped) AND artistid = \(sql: artistID) AND albumid = \(sql: albumID) AND tracknumber = \(sql: trackNumber) AND year = \(sql: year) AND duration = \(sql: duration) AND dateadded = \(sql: dateAdded, options: .quoteEscaped))"
   }
 
   func insert(artistID: String, albumID: String) -> String {
-    "INSERT INTO songs (name, sortname, itunesid, composer, tracknumber, year, duration, dateadded, datereleased, comments, artistid, albumid) VALUES (\(sql: name.name, options:.safeQuoted), \(sql: name.sorted, options:.safeQuoted), \(sql: itunesid, options: .quoted), \(sql: composer, options:.safeQuoted), \(sql: trackNumber), \(sql: year), \(sql: duration), \(sql: dateAdded, options:.quoted), \(sql: dateReleased, options:.quoted), \(sql: comments, options:.safeQuoted), \(sql: artistID), \(sql: albumID));"
+    "INSERT INTO songs (name, sortname, itunesid, composer, tracknumber, year, duration, dateadded, datereleased, comments, artistid, albumid) VALUES (\(sql: name.name, options:.quoteEscaped), \(sql: name.sorted, options:.quoteEscaped), \(sql: itunesid, options: .quoteEscaped), \(sql: composer, options:.quoteEscaped), \(sql: trackNumber), \(sql: year), \(sql: duration), \(sql: dateAdded, options:.quoteEscaped), \(sql: dateReleased, options:.quoteEscaped), \(sql: comments, options:.quoteEscaped), \(sql: artistID), \(sql: albumID));"
   }
 }

--- a/Sources/iTunes/SQL+StringInterpolation.swift
+++ b/Sources/iTunes/SQL+StringInterpolation.swift
@@ -10,10 +10,7 @@ import Foundation
 struct SQLStringOptions: OptionSet {
   let rawValue: Int
 
-  static let quoted = SQLStringOptions(rawValue: 1 << 0)
-  static let quoteEscaped = SQLStringOptions(rawValue: 1 << 1)
-
-  static let safeQuoted: SQLStringOptions = [.quoted, .quoteEscaped]
+  static let quoteEscaped = SQLStringOptions(rawValue: 1 << 0)
 }
 
 extension DefaultStringInterpolation {
@@ -25,17 +22,14 @@ extension DefaultStringInterpolation {
       return
     }
 
-    let literal =
-      options.contains(.quoteEscaped) ? string.replacingOccurrences(of: "'", with: "''") : string
-
-    guard !options.contains(.quoted) else {
-      appendLiteral("'")
-      appendLiteral(literal)
-      appendLiteral("'")
+    guard options.contains(.quoteEscaped) else {
+      appendLiteral(string)
       return
     }
 
-    appendLiteral(literal)
+    appendLiteral("'")
+    appendLiteral(string.replacingOccurrences(of: "'", with: "''"))
+    appendLiteral("'")
   }
 
   mutating func appendInterpolation(sql number: UInt, options: SQLStringOptions = []) {


### PR DESCRIPTION
- just always safe quotes the strings.
- rename the constant
- tested by comparing output before after of sql source and actual dbs.