### PR TITLE
Change iTunes persistent id to a String

### DIFF
--- a/Sources/iTunes/RowSong.swift
+++ b/Sources/iTunes/RowSong.swift
@@ -9,7 +9,7 @@ import Foundation
 import os
 
 protocol RowSongInterface {
-  var songPersistentID: UInt { get }
+  var songPersistentID: String { get }
   var songComposer: String { get }
   var songComments: String { get }
   var dateReleasedISO8601: String { get }
@@ -31,7 +31,7 @@ struct RowSong: Hashable, Sendable {
   }
 
   private init(
-    name: SortableName, itunesid: UInt, composer: String, trackNumber: Int, year: Int,
+    name: SortableName, itunesid: String, composer: String, trackNumber: Int, year: Int,
     duration: Int, dateAdded: String, dateReleased: String, comments: String
   ) {
     self.name = name
@@ -47,12 +47,12 @@ struct RowSong: Hashable, Sendable {
 
   init() {
     self.init(
-      name: SortableName(), itunesid: 0, composer: "", trackNumber: 0, year: 0, duration: 0,
+      name: SortableName(), itunesid: String(0), composer: "", trackNumber: 0, year: 0, duration: 0,
       dateAdded: "", dateReleased: "", comments: "")
   }
 
   let name: SortableName
-  let itunesid: UInt
+  let itunesid: String
   let composer: String
   let trackNumber: Int
   let year: Int

--- a/Sources/iTunes/SQL+StringInterpolation.swift
+++ b/Sources/iTunes/SQL+StringInterpolation.swift
@@ -32,10 +32,6 @@ extension DefaultStringInterpolation {
     appendLiteral("'")
   }
 
-  mutating func appendInterpolation(sql number: UInt, options: SQLStringOptions = []) {
-    appendSQLInterpolation(String(number), options: options)
-  }
-
   mutating func appendInterpolation(sql number: Int, options: SQLStringOptions = []) {
     appendSQLInterpolation(String(number), options: options)
   }

--- a/Sources/iTunes/Track+RowSong.swift
+++ b/Sources/iTunes/Track+RowSong.swift
@@ -9,8 +9,8 @@ import Foundation
 import os
 
 extension Track: RowSongInterface {
-  var songPersistentID: UInt {
-    persistentID
+  var songPersistentID: String {
+    String(persistentID)
   }
 
   var songComposer: String {


### PR DESCRIPTION
- It must be this way in the DB since SQL doesn't support the UInt type.
- this continues to reduce the SQL+StringInterpolation interface surface area.