### PR TITLE
Fix tag names when there are multiple emptys

### DIFF
--- a/Sources/iTunes/GitBackup.swift
+++ b/Sources/iTunes/GitBackup.swift
@@ -14,7 +14,11 @@ enum GitBackup {
 
 extension GitBackup {
   fileprivate func calculateBackupName(baseName: String, existingNames: [String]) -> String {
-    let existingBaseNames = existingNames.filter { $0.starts(with: baseName) }.sorted().reversed()
+    let existingBaseNames = Set(
+      existingNames.filter { $0.starts(with: baseName) }.map {
+        $0.replacingOccurrences(of: String.emptySuffix, with: "")
+      }
+    ).sorted().reversed()
     guard !existingBaseNames.isEmpty else { return baseName }
     return existingBaseNames.first!.nextTag
   }

--- a/Sources/iTunes/String+GitNames.swift
+++ b/Sources/iTunes/String+GitNames.swift
@@ -8,8 +8,10 @@
 import Foundation
 
 extension String {
+  static let emptySuffix = "-empty"
+
   var emptyTag: String {
-    return self + "-empty"
+    return self + Self.emptySuffix
   }
 
   fileprivate func appendValue(_ value: Int) -> String {

--- a/Tests/iTunes/GitBackupNameTests.swift
+++ b/Tests/iTunes/GitBackupNameTests.swift
@@ -44,6 +44,14 @@ final class GitBackupNameTests: XCTestCase {
       "B.01-empty",
       GitBackup.noChanges.backupName(baseName: BasicName, existingNames: [PreviousName, BasicName]))
     XCTAssertEqual(
+      "B.01-empty",
+      GitBackup.noChanges.backupName(
+        baseName: BasicName, existingNames: [PreviousName, BasicName, "\(BasicName)-empty"]))
+    XCTAssertEqual(
+      "B.02-empty",
+      GitBackup.noChanges.backupName(
+        baseName: BasicName, existingNames: [PreviousName, BasicName, "\(BasicName).01-empty"]))
+    XCTAssertEqual(
       "B.02-empty",
       GitBackup.noChanges.backupName(
         baseName: BasicName, existingNames: [PreviousName, BasicName, "\(BasicName).01"]))


### PR DESCRIPTION
- Prevents: tag: iTunes-2024-05-12-empty.01-empty, tag: iTunes-2024-05-12-empty