### PR TITLE
Do not cache Statements

### DIFF
--- a/Sources/iTunes/Database+CreateTable.swift
+++ b/Sources/iTunes/Database+CreateTable.swift
@@ -18,7 +18,8 @@ extension Database {
     return try self.transaction { db in
       try db.execute(tableSchema)
 
-      let statement = try db.prepare(T.insertBinding)
+      let statement = try Statement(sql: T.insertBinding, db: db)
+      defer { statement.close() }
 
       let ids = ids.isEmpty ? Array(repeating: [], count: rows.count) : ids
 


### PR DESCRIPTION
- They are used in a loop with different arguments and do not need to be cached for the lifetime of the Database.
- Move the Database.prepare() logic into the Statement.init() instead.