### PR TITLE
Use closure to get insert arguments

### DIFF
--- a/Sources/iTunes/DBEncoder.swift
+++ b/Sources/iTunes/DBEncoder.swift
@@ -18,29 +18,50 @@ final class DBEncoder {
 
   private func emitArtists() async throws -> [RowArtist: Int64] {
     let rows = rowEncoder.artistRows
-    return try await db.createTable(tableSchema: rows.tableSchema, rows: rows.rows)
+    return try await db.createTable(tableSchema: rows.tableSchema, rows: rows.rows) {
+      $0.insert.parameters
+    }
   }
 
   private func emitAlbums() async throws -> [RowAlbum: Int64] {
     let rows = rowEncoder.albumRows
-    return try await db.createTable(tableSchema: rows.tableSchema, rows: rows.rows)
+    return try await db.createTable(tableSchema: rows.tableSchema, rows: rows.rows) {
+      $0.insert.parameters
+    }
   }
 
   private func emitSongs(
     artistLookup: [RowArtist: Int64], albumLookup: [RowAlbum: Int64]
   ) async throws -> [RowSong: Int64] {
     let rows = rowEncoder.songRows
-    let ids = rows.rows.map { [artistLookup[$0.artist] ?? -1, albumLookup[$0.album] ?? -1] }
+    let artistIDs = rows.rows.reduce(into: [RowSong: Int64]()) {
+      $0[$1.song] = artistLookup[$1.artist] ?? -1
+    }
+
+    let albumIDs = rows.rows.reduce(into: [RowSong: Int64]()) {
+      $0[$1.song] = albumLookup[$1.album] ?? -1
+    }
+
     return try await db.createTable(
-      tableSchema: rows.tableSchema, rows: rows.rows.map { $0.song }, ids: ids)
+      tableSchema: rows.tableSchema, rows: rows.rows.map { $0.song }
+    ) {
+      $0.insert(artistID: "\(artistIDs[$0])", albumID: "\(albumIDs[$0])").parameters
+    }
   }
 
   @discardableResult
   private func emitPlays(songLookup: [RowSong: Int64]) async throws -> [RowPlay: Int64] {
     let rows = rowEncoder.playRows
-    let ids = rows.rows.map { [songLookup[$0.song] ?? -1] }
+
+    let songIDs = rows.rows.reduce(into: [RowPlay: Int64]()) {
+      $0[$1.play] = songLookup[$1.song] ?? -1
+    }
+
     return try await db.createTable(
-      tableSchema: rows.tableSchema, rows: rows.rows.map { $0.play! }, ids: ids)
+      tableSchema: rows.tableSchema, rows: rows.rows.map { $0.play! }
+    ) {
+      $0.insert(songid: "\(songIDs[$0])").parameters
+    }
   }
 
   func encode() async throws {

--- a/Sources/iTunes/RowAlbum+SQLBindableInsert.swift
+++ b/Sources/iTunes/RowAlbum+SQLBindableInsert.swift
@@ -9,17 +9,4 @@ import Foundation
 
 extension RowAlbum: SQLBindableInsert {
   static var insertBinding: Database.Statement { RowAlbum().insert }
-
-  func argumentsForInsert(using ids: [Int64]) throws -> [Database.Value] {
-    guard ids.isEmpty else { throw SQLBindingError.noIDsRequired }
-
-    return [
-      Database.Value.string(name.name),
-      Database.Value.string(name.sorted),
-      Database.Value.integer(Int64(trackCount)),
-      Database.Value.integer(Int64(discCount)),
-      Database.Value.integer(Int64(discNumber)),
-      Database.Value.integer(Int64(compilation)),
-    ]
-  }
 }

--- a/Sources/iTunes/RowArtist+SQLBindableInsert.swift
+++ b/Sources/iTunes/RowArtist+SQLBindableInsert.swift
@@ -9,13 +9,4 @@ import Foundation
 
 extension RowArtist: SQLBindableInsert {
   static var insertBinding: Database.Statement { RowArtist().insert }
-
-  func argumentsForInsert(using ids: [Int64]) throws -> [Database.Value] {
-    guard ids.isEmpty else { throw SQLBindingError.noIDsRequired }
-
-    return [
-      Database.Value.string(name.name),
-      Database.Value.string(name.sorted),
-    ]
-  }
 }

--- a/Sources/iTunes/RowPlay+SQLBindableInsert.swift
+++ b/Sources/iTunes/RowPlay+SQLBindableInsert.swift
@@ -9,14 +9,4 @@ import Foundation
 
 extension RowPlay: SQLBindableInsert {
   static var insertBinding: Database.Statement { RowPlay().insert(songid: .empty) }
-
-  func argumentsForInsert(using ids: [Int64]) throws -> [Database.Value] {
-    guard ids.count == 1 else { throw SQLBindingError.iDsRequired }
-
-    return [
-      Database.Value.string(date),
-      Database.Value.integer(Int64(delta)),
-      Database.Value.integer(ids[0]),
-    ]
-  }
 }

--- a/Sources/iTunes/RowSong+SQLBindableInsert.swift
+++ b/Sources/iTunes/RowSong+SQLBindableInsert.swift
@@ -11,23 +11,4 @@ extension RowSong: SQLBindableInsert {
   static var insertBinding: Database.Statement {
     RowSong().insert(artistID: .empty, albumID: .empty)
   }
-
-  func argumentsForInsert(using ids: [Int64]) throws -> [Database.Value] {
-    guard ids.count == 2 else { throw SQLBindingError.iDsRequired }
-
-    return [
-      Database.Value.string(name.name),
-      Database.Value.string(name.sorted),
-      Database.Value.string(String(itunesid)),
-      Database.Value.string(String(composer)),
-      Database.Value.integer(Int64(trackNumber)),
-      Database.Value.integer(Int64(year)),
-      Database.Value.integer(Int64(duration)),
-      Database.Value.string(dateAdded),
-      Database.Value.string(dateReleased),
-      Database.Value.string(comments),
-      Database.Value.integer(ids[0]),
-      Database.Value.integer(ids[1]),
-    ]
-  }
 }

--- a/Sources/iTunes/SQLBindableStatement.swift
+++ b/Sources/iTunes/SQLBindableStatement.swift
@@ -9,13 +9,6 @@ import Foundation
 
 protocol SQLBindableStatement {}
 
-enum SQLBindingError: Error {
-  case noIDsRequired
-  case iDsRequired
-}
-
 protocol SQLBindableInsert: SQLBindableStatement {
   static var insertBinding: Database.Statement { get }
-
-  func argumentsForInsert(using ids: [Int64]) throws -> [Database.Value]
 }


### PR DESCRIPTION
- Do not have to build an array of unused ids (if they are not needed)
- for songs and plays, need to map songs/plays to artist, album, and song ids. maybe this can be cleaned up?
- removes redundant getArgs func since each row knows its parameters.
- not sure how i feel about the string interpolation of the id to become a Database.Statement, but it works for now.