### PR TITLE
Use closures to ensure close() is after all the parts have run

### DIFF
--- a/Sources/iTunes/Database+CreateTable.swift
+++ b/Sources/iTunes/Database+CreateTable.swift
@@ -47,10 +47,11 @@ extension Database {
       try db.execute(builder.schema)
 
       let statement = try builder.preparedStatement(using: db)
-      defer { statement.close() }
 
-      return try builder.rows.reduce(into: [B.Row: Int64](minimumCapacity: builder.rows.count)) {
-        $0[$1] = try statement.insert(builder.arguments(for: $1), into: db)
+      return try statement.bindAndExecute(builder: builder, db: db) { builder, statement, db in
+        try builder.rows.reduce(into: [B.Row: Int64](minimumCapacity: builder.rows.count)) {
+          $0[$1] = try statement.insert(builder.arguments(for: $1), into: db)
+        }
       }
     }
   }

--- a/Sources/iTunes/Database.swift
+++ b/Sources/iTunes/Database.swift
@@ -183,6 +183,16 @@ actor Database {
         throw DatabaseError.unexpectedColumns(columnCount)
       }
     }
+
+    @discardableResult
+    func bindAndExecute<B: TableBuilder, R>(
+      builder: B, db: isolated Database,
+      _ action: @Sendable (B, PreparedStatement, isolated Database) throws -> R
+    ) throws -> R {
+      let result = try action(builder, self, db)
+      close()
+      return result
+    }
   }
 
   private let handle: DatabaseHandle


### PR DESCRIPTION
interesting warning from XCode 16 RC. used a similar idea to #347 for this.