### PR TITLE
Add --reduce

### DIFF
--- a/Sources/iTunes/Repair/Repair.swift
+++ b/Sources/iTunes/Repair/Repair.swift
@@ -11,7 +11,7 @@ struct Repair: Repairing {
   let issues: [Issue]
 
   public func repair(_ tracks: [Track]) -> [Track] {
-    fix(adjustDates(tracks)).filter { $0.isSQLEncodable }.map { $0.pruned }
+    fix(adjustDates(tracks))
   }
 
   private func adjustDates(_ tracks: [Track]) -> [Track] {

--- a/Sources/iTunes/Source+Tracks.swift
+++ b/Sources/iTunes/Source+Tracks.swift
@@ -8,11 +8,14 @@
 import Foundation
 
 extension Source {
-  public func gather(_ source: String?, repair: Repairing?, artistIncluded: ((String) -> Bool)?)
+  public func gather(
+    _ source: String?, repair: Repairing?, artistIncluded: ((String) -> Bool)?, reduce: Bool
+  )
     async throws -> [Track]
   {
     let tracks = try await gather(source, artistIncluded)
-    return repair != nil ? repair!.repair(tracks) : tracks
+    guard let repair else { return tracks.compactMap { $0.reducedTrack } }
+    return repair.repair(tracks).compactMap { $0.reducedTrack }
   }
 
   private func gather(_ source: String?, _ artistIncluded: ((String) -> Bool)?) async throws

--- a/Sources/iTunes/Track+Reduce.swift
+++ b/Sources/iTunes/Track+Reduce.swift
@@ -1,0 +1,15 @@
+//
+//  Track+Reduce.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 10/21/24.
+//
+
+import Foundation
+
+extension Track {
+  var reducedTrack: Track? {
+    guard self.isSQLEncodable else { return nil }
+    return self.pruned
+  }
+}


### PR DESCRIPTION
This allows the output json to be reduced to what can get into the SQL database.

It allows it to be reduced when not repairing, which is useful for iterative development comparing iTunesLibrary to MusicKit output.