### PR TITLE
Remove duplicate sort fields separately from reading from iTunesLibrary

### DIFF
--- a/Sources/iTunes/Source+Tracks.swift
+++ b/Sources/iTunes/Source+Tracks.swift
@@ -13,9 +13,14 @@ extension Source {
   )
     async throws -> [Track]
   {
-    let tracks = try await gather(source, artistIncluded).map { $0.duplicateSortFieldsRemoved }
-    guard let repair else { return reduce ? tracks.compactMap { $0.reducedTrack } : tracks }
-    return repair.repair(tracks).compactMap { $0.reducedTrack }
+    _repair(tracks: try await gather(source, artistIncluded), repair: repair).compactMap {
+      reduce ? $0.reducedTrack : $0
+    }.map { $0.duplicateSortFieldsRemoved }
+  }
+
+  private func _repair(tracks: [Track], repair: Repairing?) -> [Track] {
+    guard let repair else { return tracks }
+    return repair.repair(tracks)
   }
 
   private func gather(_ source: String?, _ artistIncluded: ((String) -> Bool)?) async throws

--- a/Sources/iTunes/Source+Tracks.swift
+++ b/Sources/iTunes/Source+Tracks.swift
@@ -13,7 +13,7 @@ extension Source {
   )
     async throws -> [Track]
   {
-    let tracks = try await gather(source, artistIncluded)
+    let tracks = try await gather(source, artistIncluded).map { $0.duplicateSortFieldsRemoved }
     guard let repair else { return reduce ? tracks.compactMap { $0.reducedTrack } : tracks }
     return repair.repair(tracks).compactMap { $0.reducedTrack }
   }

--- a/Sources/iTunes/Track+MediaItem.swift
+++ b/Sources/iTunes/Track+MediaItem.swift
@@ -16,20 +16,18 @@ extension Track {
     if let name = album.title, !name.isEmpty {
       self.album = name
     }
+    if let name = album.albumArtist {
+      self.albumArtist = name
+    }
     if album.rating != 0 {
       self.albumRating = album.rating
     }
     if album.isRatingComputed {
       self.albumRatingComputed = mediaItem.isRatingComputed
     }
-
-    if let artistName = artist?.name {
-      self.artist = artistName
-      if let albumArtistName = album.albumArtist, artistName != albumArtistName {
-        self.albumArtist = albumArtistName
-      }
+    if let name = artist?.name {
+      self.artist = name
     }
-
     //    self.ARTWORK_COUNT = mediaItem.ARTWORK_COUNT
     if mediaItem.bitrate != 0 {
       self.bitRate = mediaItem.bitrate
@@ -135,7 +133,7 @@ extension Track {
     if let sortComposer = mediaItem.sortComposer {
       self.sortComposer = sortComposer
     }
-    if let sortName = mediaItem.sortTitle, sortName != mediaItem.title {
+    if let sortName = mediaItem.sortTitle {
       self.sortName = sortName
     }
     self.totalTime = mediaItem.totalTime

--- a/Sources/iTunes/Track+ReduceSortFields.swift
+++ b/Sources/iTunes/Track+ReduceSortFields.swift
@@ -1,0 +1,39 @@
+//
+//  Track+ReduceSortFields.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 10/21/24.
+//
+
+import Foundation
+
+extension Track {
+  var duplicateSortFieldsRemoved: Track {
+    let rSortAlbum = (self.album == self.sortAlbum) ? nil : self.sortAlbum
+    let rSortAlbumArtist =
+      (self.artist == self.sortAlbumArtist)
+      ? nil : ((self.sortArtist == self.sortAlbumArtist) ? nil : self.sortAlbumArtist)
+    let rSortArtist = (self.artist == self.sortArtist) ? nil : self.sortArtist
+    let rSortComposer = (self.composer == self.sortComposer) ? nil : self.sortComposer
+    let rSortName = (self.name == self.sortName) ? nil : self.sortName
+
+    return Track(
+      album: album, albumArtist: albumArtist, albumRating: albumRating,
+      albumRatingComputed: albumRatingComputed, artist: artist, bitRate: bitRate, bPM: bPM,
+      comments: comments, compilation: compilation, composer: composer,
+      contentRating: contentRating, dateAdded: dateAdded, dateModified: dateModified,
+      disabled: disabled, discCount: discCount, discNumber: discNumber, episode: episode,
+      episodeOrder: episodeOrder, explicit: explicit, genre: genre, grouping: grouping,
+      hasVideo: hasVideo, hD: hD, kind: kind, location: location, movie: movie,
+      musicVideo: musicVideo, name: name, partOfGaplessAlbum: partOfGaplessAlbum,
+      persistentID: persistentID, playCount: playCount, playDateUTC: playDateUTC,
+      podcast: podcast, protected: protected, purchased: purchased, rating: rating,
+      ratingComputed: ratingComputed, releaseDate: releaseDate, sampleRate: sampleRate,
+      season: season, series: series, size: size, skipCount: skipCount, skipDate: skipDate,
+      sortAlbum: rSortAlbum, sortAlbumArtist: rSortAlbumArtist, sortArtist: rSortArtist,
+      sortComposer: rSortComposer, sortName: rSortName, sortSeries: sortSeries,
+      totalTime: totalTime, trackCount: trackCount, trackNumber: trackNumber,
+      trackType: trackType, tVShow: tVShow, unplayed: unplayed, videoHeight: videoHeight,
+      videoWidth: videoWidth, year: year)
+  }
+}


### PR DESCRIPTION
follow up to #397 and #393. also applies to all output.