### PR TITLE
Move Program into library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,10 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0")
   ],
   targets: [
-    .target(name: "iTunes"),
+    .target(
+      name: "iTunes",
+      dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")]),
     .testTarget(name: "iTunesTests", dependencies: ["iTunes"]),
-    .executableTarget(
-      name: "tool",
-      dependencies: [
-        .byName(name: "iTunes"), .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ]),
+    .executableTarget(name: "tool", dependencies: [.byName(name: "iTunes")]),
   ]
 )

--- a/Sources/iTunes/Program.swift
+++ b/Sources/iTunes/Program.swift
@@ -1,11 +1,10 @@
 import ArgumentParser
 import Foundation
-import iTunes
 
 extension Source: EnumerableFlag {}
 extension Destination: EnumerableFlag {}
 
-struct Program: AsyncParsableCommand {
+public struct Program: AsyncParsableCommand {
   /// Input source type.
   @Flag(help: "Input Source type. Where Track data is being read from.") var source: Source =
     .itunes
@@ -73,7 +72,7 @@ struct Program: AsyncParsableCommand {
   }
 
   /// Validates the input matrix.
-  mutating func validate() throws {
+  public mutating func validate() throws {
     if jsonSource != nil && source != .jsonString {
       throw ValidationError("Passing JSON Source requires --json-string to be passed. \(source)")
     }
@@ -109,7 +108,7 @@ struct Program: AsyncParsableCommand {
     isRepairing || reduce
   }
 
-  func run() async throws {
+  public func run() async throws {
     let tracks = try await {
       let artistIncluded: ((String) -> Bool)? = {
         if let artistNameFilter, !artistNameFilter.isEmpty {
@@ -161,4 +160,6 @@ struct Program: AsyncParsableCommand {
       Self.exit(withError: error)
     }
   }
+
+  public init() {}  // This is public and empty to help the compiler.
 }

--- a/Sources/tool/main.swift
+++ b/Sources/tool/main.swift
@@ -5,4 +5,6 @@
 //  Created by Greg Bolsinga on 12/11/23.
 //
 
+import iTunes
+
 await Program.parseStandardInAndArgumentsOrExit(arguments: CommandLine.arguments)


### PR DESCRIPTION
- This will allow this library to be used by an Xcode command line program while all vended by the Package.
- The idea is that maybe an Xcode command line program with bundle IDs and entitlements won't forget it's allowed to use Music.