### PR TITLE
Pass a descriptive name through

### DIFF
--- a/Sources/artists/Program.swift
+++ b/Sources/artists/Program.swift
@@ -70,7 +70,8 @@ struct Program: AsyncParsableCommand {
   public func run() async throws {
     let tracks = try await source.gather(
       jsonSource, repair: nil, artistIncluded: nil, reduce: false)
-    try await destination.emitArtists(for: tracks, outputFile: outputFile)
+    try await destination.emitSortableNames(
+      for: tracks, outputFile: outputFile, descriptiveName: "artists")
   }
 
   private static func readSTDIN() -> String? {

--- a/Sources/iTunes/Array+SortableName.swift
+++ b/Sources/iTunes/Array+SortableName.swift
@@ -14,15 +14,15 @@ extension Array where Element == SortableName {
     return try encoder.encode(self)
   }
 
-  func sqlData() throws -> Data {
-    try SortableNamesSQLSourceEncoder().encode(self)
+  func sqlData(tableName: String) throws -> Data {
+    try SortableNamesSQLSourceEncoder().encode(self, tableName: tableName)
   }
 
-  func database(file: URL) async throws {
+  func database(file: URL, tableName: String) async throws {
     var encoder: SortableNamesDBEncoder?
     do {
       encoder = try SortableNamesDBEncoder(
-        file: file, tableBuilder: SortableNamesTableBuilder(rows: self))
+        file: file, tableBuilder: SortableNamesTableBuilder(rows: self, tableName: tableName))
       try await encoder?.encode()
       await encoder?.close()
     } catch {

--- a/Sources/iTunes/SortableNamesDBEncoder.swift
+++ b/Sources/iTunes/SortableNamesDBEncoder.swift
@@ -18,7 +18,9 @@ struct SortableNamesDBEncoder {
 
   @discardableResult
   func encode() async throws -> [SortableName: Int64] {
-    try await db.createTable(tableBuilder, schemaConstraints: .strict)
+    let result = try await db.createTable(tableBuilder, schemaConstraints: .strict)
+    for sql in tableBuilder.dropStatements { try await db.execute(sql) }
+    return result
   }
 
   func close() async {

--- a/Sources/iTunes/SortableNamesSQLSourceEncoder.swift
+++ b/Sources/iTunes/SortableNamesSQLSourceEncoder.swift
@@ -11,7 +11,7 @@ extension SortableName: SQLBindableInsert {
   static var insertBinding: Database.Statement { SortableName().insert }
 
   var insert: Database.Statement {
-    "INSERT INTO artists (name, sortname) VALUES (\(name), \(sorted));"
+    "INSERT INTO current (name, sortname) VALUES (\(name), \(sorted));"
   }
 }
 
@@ -20,8 +20,10 @@ struct SortableNamesSQLSourceEncoder {
     case cannotMakeData
   }
 
-  func encode(_ names: [SortableName]) throws -> Data {
-    guard let data = SortableNamesTableBuilder(rows: names).encode().data(using: .utf8)
+  func encode(_ names: [SortableName], tableName: String) throws -> Data {
+    guard
+      let data = SortableNamesTableBuilder(rows: names, tableName: tableName).encode().data(
+        using: .utf8)
     else { throw SourceEncoderError.cannotMakeData }
     return data
   }

--- a/Sources/iTunes/SortableNamesTableBuilder.swift
+++ b/Sources/iTunes/SortableNamesTableBuilder.swift
@@ -9,20 +9,30 @@ import Foundation
 
 struct SortableNamesTableBuilder: TableBuilder {
   let rows: [SortableName]
+  let tableName: String
 
-  internal init(rows: [SortableName]) {
+  internal init(rows: [SortableName], tableName: String) {
     self.rows = rows.sorted()
+    self.tableName = tableName
   }
 
   func schema(constraints: SchemaConstraints = .strict) -> String {
     """
-    CREATE TABLE artists (
+    CREATE TABLE \(tableName) (
       id INTEGER PRIMARY KEY,
       name TEXT NOT NULL UNIQUE,
       sortname TEXT NOT NULL DEFAULT '',
       CHECK(length(name) > 0),
       CHECK(name != sortname)
     );
+    CREATE VIEW current AS
+      SELECT * FROM \(tableName)
+    ;
+    CREATE TRIGGER forward_insert
+      INSTEAD OF INSERT ON current
+    BEGIN
+      INSERT INTO \(tableName) (id, name, sortname) SELECT new.id, new.name, new.sortname;
+    END;
     """
   }
 
@@ -30,9 +40,17 @@ struct SortableNamesTableBuilder: TableBuilder {
 
   var argumentBuilder: (@Sendable (Row) -> [Database.Value])? { { $0.insert.parameters } }
 
+  var dropStatements: [String] {
+    [
+      "DROP VIEW IF EXISTS current;",
+      "DROP TRIGGER IF EXISTS forward_insert;",
+    ]
+  }
+
   func encode() -> String {
     var source = [schema()]
     source.append(contentsOf: statements.map { "\($0)" })
+    source.append(contentsOf: dropStatements)
     return source.joined(separator: "\n")
   }
 }


### PR DESCRIPTION
- this will allow it to build different table names
- for sqlite3, create a VIEW that will TRIGGER inserting to the proper table. This way all the insert statements do not need the table name encoded in them. It was not possible to make the tableName as a string interpolation parameter, because then the binded SQL statements would assume that was a parameter.