### PR TITLE
Rename Git.checkout(commit: String)

### DIFF
--- a/Sources/iTunes/Destination+GitWriter.swift
+++ b/Sources/iTunes/Destination+GitWriter.swift
@@ -16,7 +16,7 @@ extension URL {
 extension Git {
   func validateAndCheckout(branch: String) throws {
     try status()
-    try checkout(branch: branch)
+    try checkout(commit: branch)
   }
 
   fileprivate var latestTags: [String] {

--- a/Sources/iTunes/Git.swift
+++ b/Sources/iTunes/Git.swift
@@ -62,8 +62,8 @@ struct Git {
     try git(["status"]) { GitError.status($0) }
   }
 
-  func checkout(branch: String) throws {
-    try git(["checkout", branch]) { GitError.main($0) }
+  func checkout(commit: String) throws {
+    try git(["checkout", commit]) { GitError.main($0) }
   }
 
   func add(_ filename: String) throws {


### PR DESCRIPTION
matches what it is called in `git checkout --help`, and makes more sense when this will check out tag names too!