### PR TITLE
Use git show to read tags from git

### DIFF
--- a/Sources/iTunes/Gather/Gather.swift
+++ b/Sources/iTunes/Gather/Gather.swift
@@ -9,6 +9,7 @@ import Foundation
 import os
 
 let mainPrefix = "iTunes"
+let fileName = "itunes.json"
 
 extension Logger {
   fileprivate static let gather = Logger(
@@ -20,10 +21,6 @@ extension Array where Element == Track {
     [SortableName](
       Set(self.filter { $0.isSQLEncodable }.compactMap { $0.artistName }))
   }
-}
-
-extension URL {
-  fileprivate var itunes: URL { self.appending(path: "itunes.json") }
 }
 
 private func currentArtists() async throws -> [SortableName] {
@@ -43,12 +40,8 @@ private func trackData(from directory: URL, tagPrefix: String) async throws -> [
   for tag in tags {
     Logger.gather.info("tag: \(tag)")
 
-    try await git.checkout(commit: tag)
-
-    tagData.append(try Data(contentsOf: directory.itunes))
+    tagData.append(try await git.show(commit: tag, path: fileName))
   }
-
-  try await git.checkout(commit: "main")
 
   return tagData
 }

--- a/Sources/iTunes/Git.swift
+++ b/Sources/iTunes/Git.swift
@@ -102,6 +102,6 @@ struct Git {
   }
 
   func show(commit: String, path: String) async throws -> Data {
-    try await gitData(["--no-pager", "show", "\(commit):\(path)"]) { GitError.show($0) }
+    try await gitData(["show", "\(commit):\(path)"]) { GitError.show($0) }
   }
 }

--- a/Sources/iTunes/Git.swift
+++ b/Sources/iTunes/Git.swift
@@ -19,6 +19,7 @@ enum GitError: Error {
   case diff(Int32)
   case contains(Int32)
   case tags(Int32)
+  case show(Int32)
 }
 
 struct Git {
@@ -35,8 +36,8 @@ struct Git {
   }
 
   @discardableResult
-  fileprivate func git(_ arguments: [String], errorBuilder: (Int32) -> Error) async throws
-    -> [String]
+  fileprivate func gitData(_ arguments: [String], errorBuilder: (Int32) -> Error) async throws
+    -> Data
   {
     let gitArguments = gitPathArguments + arguments
 
@@ -44,8 +45,15 @@ struct Git {
       tool: URL(filePath: "/usr/bin/git"), arguments: gitArguments,
       suppressStandardErr: suppressStandardErr)
     guard result.0 == 0 else { throw errorBuilder(result.0) }
+    return result.1
+  }
 
-    guard let standardOutput = String(data: result.1, encoding: .utf8) else { return [] }
+  @discardableResult
+  fileprivate func git(_ arguments: [String], errorBuilder: (Int32) -> Error) async throws
+    -> [String]
+  {
+    let data = try await gitData(arguments, errorBuilder: errorBuilder)
+    guard let standardOutput = String(data: data, encoding: .utf8) else { return [] }
     return standardOutput.components(separatedBy: "\n").filter { !$0.isEmpty }
   }
 
@@ -91,5 +99,9 @@ struct Git {
 
   func tags() async throws -> [String] {
     try await git(["tag"]) { GitError.tags(($0)) }
+  }
+
+  func show(commit: String, path: String) async throws -> Data {
+    try await gitData(["--no-pager", "show", "\(commit):\(path)"]) { GitError.show($0) }
   }
 }


### PR DESCRIPTION
- This way the repository does not change on disk.
- This reads the git process output as Data, to prevent this from converting to / from Strings with newlines often.
- This sets up the code to hopefully be able to read from the git repository in parallel!