### PR TITLE
remove all non-alphanumerics to form a signature to compare for similarity

### DIFF
--- a/Sources/iTunes/Gather/String+Similar.swift
+++ b/Sources/iTunes/Gather/String+Similar.swift
@@ -26,9 +26,11 @@ extension String {
     return String(self.trimmingPrefix(regex))
   }
 
-  var trimmedForSimilarity: String {
-    self.removeCommonInitialWords.trimmingCharacters(
-      in: .whitespacesAndNewlines.union(.punctuationCharacters))
+  internal var trimmedForSimilarity: String {
+    var interim = self.removeCommonInitialWords.trimmingCharacters(
+      in: .whitespacesAndNewlines)
+    interim.unicodeScalars.removeAll(where: { CharacterSet.alphanumerics.inverted.contains($0) })
+    return interim
   }
 
   func isSimilar(to other: String) -> Bool {

--- a/Tests/iTunes/StringSimilarTests.swift
+++ b/Tests/iTunes/StringSimilarTests.swift
@@ -18,8 +18,8 @@ struct StringSimilarTests {
         "Bonnie \"Prince\" Billy",
       ],
       [
-        "3D's", "Oh Sees", "B-52's", "TORRES", "OFF", "Matt Sweeney & Bonnie 'Prince' Billy",
-        "Bonnie \"Prince\" Billy",
+        "3Ds", "OhSees", "B52s", "TORRES", "OFF", "MattSweeneyBonniePrinceBilly",
+        "BonniePrinceBilly",
       ]))
   func trimForSimilariity(original: String, expected: String) async throws {
     #expect(original.trimmedForSimilarity == expected)
@@ -29,27 +29,16 @@ struct StringSimilarTests {
     "IsSimilarTo",
     arguments: zip(
       [
-        "3D's", "Oh Sees ", "The B-52's", "TORRES", "OFF!", "Matt Sweeney & Bonnie 'Prince' Billy",
-        "Bonnie \"Prince\" Billy",
+        "3D's", "3D's", "Oh Sees ", "The B-52's", "The B-52's", "TORRES", "OFF!",
+        "Matt Sweeney & Bonnie 'Prince' Billy",
+        "Bonnie \"Prince\" Billy", "Bonnie \"Prince\" Billy",
       ],
       [
-        "The 3D's", "Oh Sees ", "B-52's", "Torres", "OFF", "Matt Sweeney & Bonnie 'Prince' Billy",
-        "Bonnie \"Prince\" Billy",
+        "The 3D's", "The 3Ds", "Oh Sees ", "B-52's", "B52's", "Torres", "OFF",
+        "Matt Sweeney & Bonnie 'Prince' Billy",
+        "Bonnie \"Prince\" Billy", "Bonnie 'Prince' Billy",
       ]))
   func isSimilarTo(original: String, other: String) async throws {
     #expect(original.isSimilar(to: other))
-  }
-
-  @Test(
-    "IsSimilarTo.Negated",
-    arguments: zip(
-      [
-        "3D's", "The B-52's", "Bonnie \"Prince\" Billy",
-      ],
-      [
-        "The 3Ds", "B52's", "Bonnie 'Prince' Billy",
-      ]))
-  func isNotSimilarTo(original: String, other: String) async throws {
-    #expect(!original.isSimilar(to: other))
   }
 }


### PR DESCRIPTION
this allows the automated "find the right artist name" code to go from not knowing 16 artists to 13.