### PR TITLE
Allow manual corrections to be passed on the command line

### DIFF
--- a/Sources/iTunes/Collection+SortableName.swift
+++ b/Sources/iTunes/Collection+SortableName.swift
@@ -1,0 +1,25 @@
+//
+//  Collection+SortableName.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 12/1/24.
+//
+
+import Foundation
+import os
+
+extension Logger {
+  fileprivate static let correction = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "unknown", category: "correction")
+}
+
+extension Collection where Element == SortableName {
+  public func correctedSimilarName(to other: Element, corrections: [String: String]) -> Element? {
+    var similarValid = self.similarName(to: other)
+    if similarValid == nil, let correction = corrections[other.name] {
+      Logger.correction.log("Corrected \(other.name) to \(correction)")
+      similarValid = self.similarName(to: SortableName(name: correction))
+    }
+    return similarValid
+  }
+}

--- a/Sources/patch/PatchMusic.swift
+++ b/Sources/patch/PatchMusic.swift
@@ -28,9 +28,21 @@ struct PatchMusic: AsyncParsableCommand {
 
   @Option(help: "The prefix to use for the git tags.") var sourceTagPrefix: String = "iTunes"
 
+  /// Optional corrections to use when creating this patch.
+  @Option(
+    help: "The corrections to apply when creating this patch (as a JSON string).",
+    transform: ({
+      guard let data = $0.data(using: .utf8) else {
+        throw ValidationError("Invalid Correction String: \($0)")
+      }
+      return try JSONDecoder().decode(Dictionary<String, String>.self, from: data)
+    })
+  )
+  var correction: [String: String] = [:]
+
   public func run() async throws {
     let configuration = GitTagDataSequence.Configuration(
       directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: fileName)
-    print(try await repairable.gather(configuration))
+    print(try await repairable.gather(configuration, corrections: correction))
   }
 }

--- a/Sources/patch/Repairable+Gather.swift
+++ b/Sources/patch/Repairable+Gather.swift
@@ -27,7 +27,9 @@ private func changes<Guide: Hashable & Similar, Change: Sendable>(
 }
 
 extension Repairable {
-  func gather(_ configuration: GitTagDataSequence.Configuration) async throws -> Patch {
+  func gather(_ configuration: GitTagDataSequence.Configuration, corrections: [String: String])
+    async throws -> Patch
+  {
     switch self {
     case .artists:
       return .artists(
@@ -36,7 +38,7 @@ extension Repairable {
         } createGuide: {
           $0.artistNames
         } createChange: {
-          ArtistPatch(invalid: $0, valid: $1.similarName(to: $0))
+          ArtistPatch(invalid: $0, valid: $1.correctedSimilarName(to: $0, corrections: corrections))
         })
     case .albums:
       return .albums(


### PR DESCRIPTION
patch --correction "{\"Jason Lowenstein\":\"Jason Loewenstein\"}"

It's a JSON dictionary. The key is the "bad name" (usually a misspelling that is not similar to anything current). The value is the name to use for finding similarities on a second pass.