### PR TITLE
Add repair tool

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     .library(name: "iTunes", targets: ["iTunes"]),
     .executable(name: "itunes_json", targets: ["tool"]),
     .executable(name: "patch", targets: ["patch"]),
+    .executable(name: "repair", targets: ["repair"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0")
@@ -22,5 +23,6 @@ let package = Package(
     .testTarget(name: "iTunesTests", dependencies: ["iTunes"]),
     .executableTarget(name: "tool", dependencies: [.byName(name: "iTunes")]),
     .executableTarget(name: "patch", dependencies: [.byName(name: "iTunes")]),
+    .executableTarget(name: "repair", dependencies: [.byName(name: "iTunes")]),
   ]
 )

--- a/Sources/iTunes/Git.swift
+++ b/Sources/iTunes/Git.swift
@@ -20,6 +20,7 @@ enum GitError: Error {
   case contains(Int32)
   case tags(Int32)
   case show(Int32)
+  case createBranch(Int32)
 }
 
 struct Git {
@@ -103,5 +104,9 @@ struct Git {
 
   func show(commit: String, path: String) async throws -> Data {
     try await gitData(["show", "\(commit):\(path)"]) { GitError.show($0) }
+  }
+
+  func createBranch(named name: String, initialCommit: String) async throws {
+    try await git(["checkout", "-b", name, initialCommit]) { GitError.createBranch($0) }
   }
 }

--- a/Sources/iTunes/Track+Patch.swift
+++ b/Sources/iTunes/Track+Patch.swift
@@ -1,0 +1,177 @@
+//
+//  Track+Patch.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 12/2/24.
+//
+
+import Foundation
+import os
+
+extension Logger {
+  fileprivate static let patch = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "unknown", category: "patch")
+}
+
+extension Track {
+  fileprivate func apply(patch: ArtistPatchLookup.Value) -> Track {
+    Logger.patch.info("Patching: \(patch)")
+
+    return Track(
+      album: album,
+      albumArtist: albumArtist,
+      albumRating: albumRating,
+      albumRatingComputed: albumRatingComputed,
+      artist: patch.name,
+      bitRate: bitRate,
+      bPM: bPM,
+      comments: comments,
+      compilation: compilation,
+      composer: composer,
+      contentRating: contentRating,
+      dateAdded: dateAdded,
+      dateModified: dateModified,
+      disabled: disabled,
+      discCount: discCount,
+      discNumber: discNumber,
+      episode: episode,
+      episodeOrder: episodeOrder,
+      explicit: explicit,
+      genre: genre,
+      grouping: grouping,
+      hasVideo: hasVideo,
+      hD: hD,
+      kind: kind,
+      location: location,
+      movie: movie,
+      musicVideo: musicVideo,
+      name: name,
+      partOfGaplessAlbum: partOfGaplessAlbum,
+      persistentID: persistentID,
+      playCount: playCount,
+      playDateUTC: playDateUTC,
+      podcast: podcast,
+      protected: protected,
+      purchased: purchased,
+      rating: rating,
+      ratingComputed: ratingComputed,
+      releaseDate: releaseDate,
+      sampleRate: sampleRate,
+      season: season,
+      series: series,
+      size: size,
+      skipCount: skipCount,
+      skipDate: skipDate,
+      sortAlbum: sortAlbum,
+      sortAlbumArtist: sortAlbumArtist,
+      sortArtist: patch.sorted,
+      sortComposer: sortComposer,
+      sortName: sortName,
+      sortSeries: sortSeries,
+      totalTime: totalTime,
+      trackCount: trackCount,
+      trackNumber: trackNumber,
+      trackType: trackType,
+      tVShow: tVShow,
+      unplayed: unplayed,
+      videoHeight: videoHeight,
+      videoWidth: videoWidth,
+      year: year,
+      isrc: isrc)
+  }
+
+  fileprivate func apply(patch: AlbumPatchLookup.Value) -> Track {
+    Logger.patch.info("Patching: \(patch)")
+
+    return Track(
+      album: patch.name.name,
+      albumArtist: albumArtist,
+      albumRating: albumRating,
+      albumRatingComputed: albumRatingComputed,
+      artist: artist,
+      bitRate: bitRate,
+      bPM: bPM,
+      comments: comments,
+      compilation: compilation,
+      composer: composer,
+      contentRating: contentRating,
+      dateAdded: dateAdded,
+      dateModified: dateModified,
+      disabled: disabled,
+      discCount: discCount,
+      discNumber: discNumber,
+      episode: episode,
+      episodeOrder: episodeOrder,
+      explicit: explicit,
+      genre: genre,
+      grouping: grouping,
+      hasVideo: hasVideo,
+      hD: hD,
+      kind: kind,
+      location: location,
+      movie: movie,
+      musicVideo: musicVideo,
+      name: name,
+      partOfGaplessAlbum: partOfGaplessAlbum,
+      persistentID: persistentID,
+      playCount: playCount,
+      playDateUTC: playDateUTC,
+      podcast: podcast,
+      protected: protected,
+      purchased: purchased,
+      rating: rating,
+      ratingComputed: ratingComputed,
+      releaseDate: releaseDate,
+      sampleRate: sampleRate,
+      season: season,
+      series: series,
+      size: size,
+      skipCount: skipCount,
+      skipDate: skipDate,
+      sortAlbum: patch.name.sorted,
+      sortAlbumArtist: sortAlbumArtist,
+      sortArtist: sortArtist,
+      sortComposer: sortComposer,
+      sortName: sortName,
+      sortSeries: sortSeries,
+      totalTime: totalTime,
+      trackCount: trackCount,
+      trackNumber: trackNumber,
+      trackType: trackType,
+      tVShow: tVShow,
+      unplayed: unplayed,
+      videoHeight: videoHeight,
+      videoWidth: videoWidth,
+      year: year,
+      isrc: isrc)
+  }
+}
+
+extension Array where Element == Track {
+  fileprivate func patchArtists(_ lookup: ArtistPatchLookup) throws -> [Track] {
+    self.map { track in
+      guard let name = track.artistName, let patch = lookup[name] else { return track }
+      return track.apply(patch: patch)
+    }
+  }
+
+  fileprivate func patchAlbums(_ lookup: AlbumPatchLookup) throws -> [Track] {
+    self.map { track in
+      guard let name = track.albumArtistName, let patch = lookup[name] else { return track }
+      return track.apply(patch: patch)
+    }
+  }
+
+  fileprivate func patchTracks(_ patch: Patch) throws -> [Track] {
+    switch patch {
+    case .artists(let lookup):
+      try patchArtists(lookup)
+    case .albums(let lookup):
+      try patchAlbums(lookup)
+    }
+  }
+
+  public func patch(_ patch: Patch) throws -> Data {
+    try patchTracks(patch).jsonData()
+  }
+}

--- a/Sources/repair/Patch+Build.swift
+++ b/Sources/repair/Patch+Build.swift
@@ -1,0 +1,25 @@
+//
+//  Patchable+Build.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 12/2/24.
+//
+
+import Foundation
+import iTunes
+
+extension Patch {
+  func patch(
+    sourceConfiguration: GitTagData.Configuration, patch: Patch, tagAppendix: String,
+    destinationConfiguration: GitTagData.Configuration
+  ) async throws {
+    let patchedTracksData = try await GitTagData(configuration: sourceConfiguration)
+      .transformTaggedTracks { try $0.patch(patch) }
+
+    guard let initialCommit = patchedTracksData.initialCommit else { return }
+
+    try await GitTagData(configuration: destinationConfiguration).write(
+      tagDatum: patchedTracksData.addTagAppendix(tagAppendix: tagAppendix),
+      initialCommit: initialCommit)
+  }
+}

--- a/Sources/repair/Patchable.swift
+++ b/Sources/repair/Patchable.swift
@@ -1,0 +1,13 @@
+//
+//  Patchable.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 12/2/24.
+//
+
+import Foundation
+
+enum Patchable: String, CaseIterable {
+  case artists
+  case albums
+}

--- a/Sources/repair/RepairMusic.swift
+++ b/Sources/repair/RepairMusic.swift
@@ -1,0 +1,88 @@
+import ArgumentParser
+import Foundation
+import iTunes
+
+let fileName = "itunes.json"
+
+extension Patchable: EnumerableFlag {}
+
+extension Dictionary where Key: Codable & Comparable, Value: Codable & Comparable, Key == Value {
+  static fileprivate func load(from url: URL) throws -> Self {
+    try load(from: try Data(contentsOf: url, options: .mappedIfSafe))
+  }
+
+  static fileprivate func load(from data: Data) throws -> Self {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try decoder.decode(Self.self, from: data)
+  }
+}
+
+extension Patchable {
+  fileprivate func createPatch(_ fileURL: URL) throws -> Patch {
+    switch self {
+    case .artists:
+      Patch.artists(try ArtistPatchLookup.load(from: fileURL))
+    case .albums:
+      Patch.albums(try AlbumPatchLookup.load(from: fileURL))
+    }
+  }
+}
+
+@main
+struct RepairMusic: AsyncParsableCommand {
+  /// Input source type.
+  @Flag(help: "Patchable type to build.") var patchable: Patchable = .artists
+
+  /// Git Directory to read and write data from.
+  @Option(
+    help: "The path for the git directory to work with.",
+    transform: ({
+      let url = URL(filePath: $0, directoryHint: .isDirectory)
+      let manager = FileManager.default
+      if !manager.fileExists(atPath: url.relativePath) {
+        try manager.createDirectory(at: url, withIntermediateDirectories: true)
+      }
+
+      return url
+    })
+  )
+  var gitDirectory: URL
+
+  /// Patch File URL.
+  @Option(
+    help: "Patch JSON file path.",
+    transform: ({ URL(filePath: $0) })
+  )
+  var patchURL: URL
+
+  @Option(help: "The prefix to use for the source git tags.") var sourceTagPrefix: String = "iTunes"
+
+  @Option(
+    help:
+      "The string to append to the sourceTagPrefix for the destination git branch. Defaults to the patchable type name."
+  )
+  var destinationTagAppendix: String?
+
+  @Option(help: "The destination git branch. Defaults to the patchable type name.")
+  var destinationBranch: String?
+
+  public func run() async throws {
+    let patch = try patchable.createPatch(patchURL)
+
+    let sourceConfiguration = GitTagData.Configuration(
+      directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: fileName)
+
+    let tagAppendix = destinationTagAppendix ?? patchable.rawValue
+    let destinationBranch = destinationBranch ?? patchable.rawValue
+
+    let destinationConfiguration = GitTagData.Configuration(
+      directory: gitDirectory, branch: destinationBranch, fileName: fileName)
+
+    try await patch.patch(
+      sourceConfiguration: sourceConfiguration,
+      patch: patch,
+      tagAppendix: tagAppendix,
+      destinationConfiguration: destinationConfiguration)
+  }
+}


### PR DESCRIPTION
- This seems better than the "old" repair. It will read patch files created by the patch tool. It will then go through all the given tags in a git repository, and patch them. It will then checkout a new branch, and commit all the patched data with a new git tag prefix, preserving the date stamp.
- One issue that needs to be examined: Data.write(to:) seems to leak memory!
- Does not yet push the branch nor the tags. Need to verify this data in a subsequent diff, but I don't want to hold back on landing this code. I want to re-write one of the shell scripts making the git repo into make .sql or .db files into an actual tool.