### PR TITLE
nextTag now handles multiple "." in the string

### DIFF
--- a/Sources/iTunes/String+GitNames.swift
+++ b/Sources/iTunes/String+GitNames.swift
@@ -14,11 +14,15 @@ extension String {
     return self + Self.emptySuffix
   }
 
-  fileprivate func appendValue(_ value: Int) -> String {
+  fileprivate static func twoDigits(_ value: Int) -> String {
     let formatter = NumberFormatter()
     formatter.minimumIntegerDigits = 2
-    guard let r = formatter.string(from: value as NSNumber) else { return self }
-    return self + "." + r
+    guard let r = formatter.string(from: value as NSNumber) else { return "" }
+    return r
+  }
+
+  fileprivate func appendValue(_ value: Int) -> String {
+    return self + ".\(Self.twoDigits(value))"
   }
 
   var nextTag: String {
@@ -27,9 +31,14 @@ extension String {
     switch parts.count {
     case 1:
       return self.appendValue(1)
-    case 2:
-      guard let index = Int(parts[1]) else { return self }
-      return parts[0].appendValue(index + 1)
+    case 2...Int.max:
+      guard let lastPart = parts.last else {
+        return self
+      }
+      guard let value = Int(lastPart) else {
+        return self.appendValue(1)
+      }
+      return self.replacingOccurrences(of: lastPart, with: Self.twoDigits(value + 1))
     default:
       return self
     }

--- a/Tests/iTunes/GitBackupNameTests.swift
+++ b/Tests/iTunes/GitBackupNameTests.swift
@@ -84,4 +84,12 @@ struct GitBackupNameTests {
         == GitBackup.changes.backupName(
           baseName: BasicName, existingNames: [PreviousName, BasicName, SubsequentName]))
   }
+
+  @Test func newstuff() {
+    #expect(
+      "iTunes.artists-2024-12-11.02"
+        == GitBackup.changes.backupName(
+          baseName: "iTunes.artists-2024-12-11",
+          existingNames: ["iTunes.artists-2024-12-11", "iTunes.artists-2024-12-11.01"]))
+  }
 }

--- a/Tests/iTunes/StringGitNameTests.swift
+++ b/Tests/iTunes/StringGitNameTests.swift
@@ -12,6 +12,7 @@ import Testing
 struct StringGitNameTests {
   @Test func empty() {
     #expect("name-empty" == "name".emptyTag)
+    #expect("name.it-empty" == "name.it".emptyTag)
   }
 
   @Test func next_none() {
@@ -26,15 +27,20 @@ struct StringGitNameTests {
     #expect("name.02" == "name.01".nextTag)
   }
 
-  @Test func next_notCannonical() {
-    #expect("name.it.now" == "name.it.now".nextTag)
+  @Test func next_withDots_incremental() {
+    #expect("name.it.02" == "name.it.1".nextTag)
   }
 
-  @Test func next_notCannonicalIntegral() {
-    #expect("name.it.1" == "name.it.1".nextTag)
+  @Test func next_withDots_incrementalWithLeadingZero() {
+    #expect("name.it.02" == "name.it.01".nextTag)
   }
 
   @Test func next_notIntegral() {
-    #expect("name.it" == "name.it".nextTag)
+    #expect("name.it.01" == "name.it".nextTag)
+  }
+
+  @Test func next_wacky() {
+    #expect("name.02.02" == "name.01.01".nextTag)  // Bug
+    #expect("name.01.02" != "name.01.01".nextTag)  // Desired
   }
 }


### PR DESCRIPTION
- it has a degenerate case, but that won't happen at this moment.