### PR TITLE
Improve album patching

### DIFF
--- a/Sources/iTunes/Album+Changes.swift
+++ b/Sources/iTunes/Album+Changes.swift
@@ -15,7 +15,7 @@ extension Track {
 
   private var albumType: AlbumArtistName.AlbumType {
     if isCompilation {
-      .compilation
+      .compilation(artist)
     } else if let artistName = artistName {
       .artist(artistName.name)
     } else {

--- a/Sources/iTunes/AlbumArtistName.swift
+++ b/Sources/iTunes/AlbumArtistName.swift
@@ -9,24 +9,37 @@ import Foundation
 
 public struct AlbumArtistName: Codable, Comparable, Hashable, Sendable {
   enum AlbumType: Codable, Hashable {
-    case compilation
+    case compilation(String?)
     case artist(String)
     case unknown
 
     func isSimilar(to other: AlbumType) -> Bool {
       // self is current here
       switch (self, other) {
-      case (.compilation, .compilation):
-        return true
+      case (.compilation(let sa), .compilation(let oa)):
+        guard let sa, let oa else { return false }
+        return sa.isSimilar(to: oa)
       case (.artist(let sa), .artist(let oa)):
         return sa.isSimilar(to: oa)
       case (.unknown, .unknown):
         return true
-      case (.compilation, .artist(_)):
-        // self says it is a compilation, but the old code says it is not. trust the current version.
-        return true
+      case (.artist(let sa), .compilation(let oa)):
+        /// No equivalent in reverse, as that will remove fixes.
+        guard let oa else { return false }
+        return sa.isSimilar(to: oa)
       default:
         return false
+      }
+    }
+
+    var artist: String? {
+      switch self {
+      case .compilation(let artist):
+        artist
+      case .artist(let artist):
+        artist
+      case .unknown:
+        nil
       }
     }
   }
@@ -36,6 +49,14 @@ public struct AlbumArtistName: Codable, Comparable, Hashable, Sendable {
 
   public static func < (lhs: AlbumArtistName, rhs: AlbumArtistName) -> Bool {
     lhs.name < rhs.name
+  }
+
+  func update(name: String) -> AlbumArtistName {
+    AlbumArtistName(name: SortableName(name: name), type: self.type)
+  }
+
+  func updateToCompilation() -> AlbumArtistName {
+    AlbumArtistName(name: name, type: .compilation(type.artist))
   }
 }
 

--- a/Sources/iTunes/Collection+AlbumArtistName.swift
+++ b/Sources/iTunes/Collection+AlbumArtistName.swift
@@ -1,0 +1,32 @@
+//
+//  Collection+AlbumArtistName.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 12/11/24.
+//
+
+import Foundation
+import os
+
+extension Logger {
+  fileprivate static let albumCorrection = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "unknown", category: "albumCorrection")
+}
+
+extension Collection where Element == AlbumArtistName {
+  public func correctedSimilarName(to other: Element, corrections: [String: String]) -> Element? {
+    var similarValid = self.similarName(to: other)
+    if similarValid == nil, let correction = corrections[other.name.name] {
+      Logger.albumCorrection.log("Corrected \(other.name.name) to \(correction)")
+      switch correction {
+      case "--COMPILATION--":
+        // Change named album to a compilation.
+        similarValid = self.similarName(to: other.updateToCompilation())
+      default:
+        // Change the name of the album.
+        similarValid = self.similarName(to: other.update(name: correction))
+      }
+    }
+    return similarValid
+  }
+}

--- a/Sources/patch/Repairable+Gather.swift
+++ b/Sources/patch/Repairable+Gather.swift
@@ -56,7 +56,7 @@ extension Repairable {
         } createGuide: {
           $0.albumNames
         } createChange: {
-          guard let valid = $1.similarName(to: $0) else {
+          guard let valid = $1.correctedSimilarName(to: $0, corrections: corrections) else {
             return nil
           }
           return ($0, valid)


### PR DESCRIPTION
- AlbumType.compilation now takes a String? for the artist name. -- Helps when albums move to .compilation since the artist name can be compared.
- add album corrections. -- Album name to a new name for spelling issues.
-- Album name to magic --COMPILATION-- for changing the type.