### PR TITLE
Repair music now requires a tag prefix to replace the old one

### DIFF
--- a/Sources/iTunes/GitTagData.swift
+++ b/Sources/iTunes/GitTagData.swift
@@ -52,14 +52,14 @@ extension TagData {
 }
 
 extension String {
-  fileprivate func appendTag(appendix: String) -> String {
-    appendToPrefix(appendix: appendix) ?? "\(self)-Could-Not-Properly-Append-\(appendix)"
+  fileprivate func replaceTagPrefix(tagPrefix: String) -> String {
+    replacePrefix(newPrefix: tagPrefix) ?? "\(self)-Could-Not-Properly-Replace-\(tagPrefix)"
   }
 }
 
 extension Array where Element == TagData {
-  public func addTagAppendix(tagAppendix: String) -> [Element] {
-    self.map { TagData(tag: $0.tag.appendTag(appendix: tagAppendix), data: $0.data) }
+  public func replaceTagPrefix(tagPrefix: String) -> [Element] {
+    self.map { TagData(tag: $0.tag.replaceTagPrefix(tagPrefix: tagPrefix), data: $0.data) }
   }
 
   public var initialCommit: String? {

--- a/Sources/repair/Patch+Build.swift
+++ b/Sources/repair/Patch+Build.swift
@@ -10,7 +10,7 @@ import iTunes
 
 extension Patch {
   func patch(
-    sourceConfiguration: GitTagData.Configuration, patch: Patch, tagAppendix: String,
+    sourceConfiguration: GitTagData.Configuration, patch: Patch, destinationTagPrefix: String,
     destinationConfiguration: GitTagData.Configuration
   ) async throws {
     let patchedTracksData = try await GitTagData(configuration: sourceConfiguration)
@@ -19,7 +19,7 @@ extension Patch {
     guard let initialCommit = patchedTracksData.initialCommit else { return }
 
     try await GitTagData(configuration: destinationConfiguration).write(
-      tagDatum: patchedTracksData.addTagAppendix(tagAppendix: tagAppendix),
+      tagDatum: patchedTracksData.replaceTagPrefix(tagPrefix: destinationTagPrefix),
       initialCommit: initialCommit)
   }
 }

--- a/Sources/repair/RepairMusic.swift
+++ b/Sources/repair/RepairMusic.swift
@@ -60,9 +60,9 @@ struct RepairMusic: AsyncParsableCommand {
 
   @Option(
     help:
-      "The string to append to the sourceTagPrefix for the destination git branch. Defaults to the patchable type name."
+      "The string to append to the sourceTagPrefix for the destination git branch."
   )
-  var destinationTagAppendix: String?
+  var destinationTagPrefix: String
 
   @Option(help: "The destination git branch. Defaults to the patchable type name.")
   var destinationBranch: String?
@@ -73,7 +73,6 @@ struct RepairMusic: AsyncParsableCommand {
     let sourceConfiguration = GitTagData.Configuration(
       directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: fileName)
 
-    let tagAppendix = destinationTagAppendix ?? patchable.rawValue
     let destinationBranch = destinationBranch ?? patchable.rawValue
 
     let destinationConfiguration = GitTagData.Configuration(
@@ -82,7 +81,7 @@ struct RepairMusic: AsyncParsableCommand {
     try await patch.patch(
       sourceConfiguration: sourceConfiguration,
       patch: patch,
-      tagAppendix: tagAppendix,
+      destinationTagPrefix: destinationTagPrefix,
       destinationConfiguration: destinationConfiguration)
   }
 }


### PR DESCRIPTION
- appending would have just made the tags very long over time.