### PR TITLE
remove backing up from json strings

### DIFF
--- a/Sources/iTunes/Source+Tracks.swift
+++ b/Sources/iTunes/Source+Tracks.swift
@@ -20,8 +20,6 @@ extension Source {
       return try Track.gatherAllTracks()
     case .musickit:
       return try await Track.gatherWithMusicKit()
-    case .jsonString(let source):
-      return try Track.array(from: source)
     }
   }
 }

--- a/Sources/iTunes/Source.swift
+++ b/Sources/iTunes/Source.swift
@@ -8,11 +8,9 @@
 import Foundation
 
 /// The source of the data to be converted into a Track.
-public enum Source {
+public enum Source: CaseIterable {
   /// Retreive Track data using the iTunesLibrary.
   case itunes
   /// Retreive Track data using MusicKit.
   case musickit
-  /// Retreive Track data using existing Track JSON strings.
-  case jsonString(String)
 }

--- a/Sources/tool/main.swift
+++ b/Sources/tool/main.swift
@@ -7,4 +7,4 @@
 
 import iTunes
 
-await Program.parseStandardInAndArgumentsOrExit(arguments: CommandLine.arguments)
+await Program.run(arguments: CommandLine.arguments)


### PR DESCRIPTION
remove stdin parsing code too.
This was needed when reading files out of git with shell scripts. With the new tools, this is not necessary.