### PR TITLE
Add PatchCommand sub command to the main program.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,6 @@ let package = Package(
   products: [
     .library(name: "iTunes", targets: ["iTunes"]),
     .executable(name: "itunes_json", targets: ["tool"]),
-    .executable(name: "patch", targets: ["patch"]),
     .executable(name: "repair", targets: ["repair"]),
     .executable(name: "batch", targets: ["batch"]),
   ],
@@ -23,7 +22,6 @@ let package = Package(
       dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")]),
     .testTarget(name: "iTunesTests", dependencies: ["iTunes"]),
     .executableTarget(name: "tool", dependencies: [.byName(name: "iTunes")]),
-    .executableTarget(name: "patch", dependencies: [.byName(name: "iTunes")]),
     .executableTarget(name: "repair", dependencies: [.byName(name: "iTunes")]),
     .executableTarget(name: "batch", dependencies: [.byName(name: "iTunes")]),
   ]

--- a/Sources/iTunes/Album+Changes.swift
+++ b/Sources/iTunes/Album+Changes.swift
@@ -30,11 +30,11 @@ extension Track {
 }
 
 extension Array where Element == Track {
-  public var albumNames: Set<AlbumArtistName> {
+  var albumNames: Set<AlbumArtistName> {
     Set(self.filter { $0.isSQLEncodable }.compactMap { $0.albumArtistName })
   }
 }
 
-public func currentAlbums() async throws -> Set<AlbumArtistName> {
+func currentAlbums() async throws -> Set<AlbumArtistName> {
   try await Source.itunes.gather(reduce: false).albumNames
 }

--- a/Sources/iTunes/AlbumArtistName+Similar.swift
+++ b/Sources/iTunes/AlbumArtistName+Similar.swift
@@ -6,11 +6,11 @@
 //
 
 extension AlbumArtistName: Similar {
-  public var cullable: Bool {
+  var cullable: Bool {
     true  // FIXME
   }
 
-  public func isSimilar(to other: AlbumArtistName) -> Bool {
+  func isSimilar(to other: AlbumArtistName) -> Bool {
     // self is the current here.
     self.name.isSimilar(to: other.name) && self.type.isSimilar(to: other.type)
   }

--- a/Sources/iTunes/AlbumCorrection.swift
+++ b/Sources/iTunes/AlbumCorrection.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-public struct AlbumCorrection: Codable, Sendable {
+struct AlbumCorrection: Codable, Sendable {
   let rename: [String: String]
   let compilation: Set<String>
 
-  public init(rename: [String: String] = [:], compilation: Set<String> = []) {
+  init(rename: [String: String] = [:], compilation: Set<String> = []) {
     self.rename = rename
     self.compilation = compilation
   }

--- a/Sources/iTunes/Artist+Changes.swift
+++ b/Sources/iTunes/Artist+Changes.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 extension Array where Element == Track {
-  public var artistNames: Set<SortableName> {
+  var artistNames: Set<SortableName> {
     Set(self.filter { $0.isSQLEncodable }.compactMap { $0.artistName })
   }
 }
 
-public func currentArtists() async throws -> Set<SortableName> {
+func currentArtists() async throws -> Set<SortableName> {
   try await Source.itunes.gather(reduce: false).artistNames
 }

--- a/Sources/iTunes/Collection+AlbumArtistName.swift
+++ b/Sources/iTunes/Collection+AlbumArtistName.swift
@@ -14,7 +14,7 @@ extension Logger {
 }
 
 extension Collection where Element == AlbumArtistName {
-  public func correctedSimilarName(to other: Element, correction: AlbumCorrection) -> Element? {
+  func correctedSimilarName(to other: Element, correction: AlbumCorrection) -> Element? {
     var similarValid = self.similarName(to: other)
     if similarValid == nil {
       if let rename = correction.rename[other.name.name] {

--- a/Sources/iTunes/Collection+Changes.swift
+++ b/Sources/iTunes/Collection+Changes.swift
@@ -6,7 +6,7 @@
 //
 
 extension Collection where Element: Similar {
-  public func changes<T: Sendable>(createChange: @escaping @Sendable (Element) -> T?) async -> [T] {
+  func changes<T: Sendable>(createChange: @escaping @Sendable (Element) -> T?) async -> [T] {
     await withTaskGroup(of: Optional<T>.self) { group in
       self.forEach { element in
         group.addTask { createChange(element) }

--- a/Sources/iTunes/Collection+Similar.swift
+++ b/Sources/iTunes/Collection+Similar.swift
@@ -18,7 +18,7 @@ extension Collection where Element: Similar {
     self.filter { $0.isSimilar(to: other) }
   }
 
-  public func similarName(to other: Element) -> Element? {
+  func similarName(to other: Element) -> Element? {
     // 'self' contains the current names here.
     var similarNames = self.similarNames(to: other)
     let originalCount = similarNames.count

--- a/Sources/iTunes/Collection+SortableName.swift
+++ b/Sources/iTunes/Collection+SortableName.swift
@@ -14,7 +14,7 @@ extension Logger {
 }
 
 extension Collection where Element == SortableName {
-  public func correctedSimilarName(to other: Element, corrections: [String: String]) -> Element? {
+  func correctedSimilarName(to other: Element, corrections: [String: String]) -> Element? {
     var similarValid = self.similarName(to: other)
     if similarValid == nil, let correction = corrections[other.name] {
       Logger.correction.log("Corrected \(other.name) to \(correction)")

--- a/Sources/iTunes/Patch/PatchCommand.swift
+++ b/Sources/iTunes/Patch/PatchCommand.swift
@@ -1,13 +1,16 @@
 import ArgumentParser
 import Foundation
-import iTunes
-
-let fileName = "itunes.json"
 
 extension Repairable: EnumerableFlag {}
 
-@main
-struct PatchMusic: AsyncParsableCommand {
+public struct PatchCommand: AsyncParsableCommand {
+  private static let fileName = "itunes.json"
+
+  public static let configuration = CommandConfiguration(
+    commandName: "patch",
+    abstract: "Creates patches for itunes.json data."
+  )
+
   /// Input source type.
   @Flag(help: "Repairable type to build.") var repairable: Repairable = .artists
 
@@ -34,7 +37,9 @@ struct PatchMusic: AsyncParsableCommand {
 
   public func run() async throws {
     let configuration = GitTagData.Configuration(
-      directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: fileName)
+      directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: PatchCommand.fileName)
     print(try await repairable.gather(configuration, correction: correction))
   }
+
+  public init() {}  // This is public and empty to help the compiler.
 }

--- a/Sources/iTunes/Patch/Repairable+Gather.swift
+++ b/Sources/iTunes/Patch/Repairable+Gather.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import iTunes
 
 private func changes<Guide: Hashable & Similar, Change: Sendable>(
   configuration: GitTagData.Configuration,

--- a/Sources/iTunes/Patch/Repairable.swift
+++ b/Sources/iTunes/Patch/Repairable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum Repairable: CaseIterable {
+enum Repairable: CaseIterable {
   case artists
   case albums
 }

--- a/Sources/iTunes/Similar.swift
+++ b/Sources/iTunes/Similar.swift
@@ -5,7 +5,7 @@
 //  Created by Greg Bolsinga on 11/30/24.
 //
 
-public protocol Similar: Sendable {
+protocol Similar: Sendable {
   func isSimilar(to other: Self) -> Bool
   var cullable: Bool { get }
 }

--- a/Sources/iTunes/SortableName+Similar.swift
+++ b/Sources/iTunes/SortableName+Similar.swift
@@ -6,11 +6,11 @@
 //
 
 extension SortableName: Similar {
-  public var cullable: Bool {
+  var cullable: Bool {
     sorted.isEmpty
   }
 
-  public func isSimilar(to other: SortableName) -> Bool {
+  func isSimilar(to other: SortableName) -> Bool {
     self.name.isSimilar(to: other.name)
   }
 }

--- a/Sources/tool/Program.swift
+++ b/Sources/tool/Program.swift
@@ -6,7 +6,7 @@ import iTunes
 public struct Program: AsyncParsableCommand {
   public static let configuration = CommandConfiguration(
     abstract: "A tool for working with iTunes data.",
-    subcommands: [Backup.self],
+    subcommands: [Backup.self, PatchCommand.self],
     defaultSubcommand: Backup.self
   )
 


### PR DESCRIPTION
Move the patch specific code to a sub directory in the library. Many public things may now become internal.