### PR TITLE
TunesCommand is now part of the library

### DIFF
--- a/Sources/iTunes/Tunes/TunesCommand.swift
+++ b/Sources/iTunes/Tunes/TunesCommand.swift
@@ -1,9 +1,7 @@
 import ArgumentParser
 import Foundation
-import iTunes
 
-@main
-public struct Program: AsyncParsableCommand {
+public struct TunesCommand: AsyncParsableCommand {
   public static let configuration = CommandConfiguration(
     commandName: "tunes",
     abstract: "A tool for working with iTunes data.",
@@ -13,4 +11,8 @@ public struct Program: AsyncParsableCommand {
   )
 
   public init() {}  // This is public and empty to help the compiler.
+
+  public static func go(_ arguments: [String]?) async {
+    await Self.main(arguments)
+  }
 }

--- a/Sources/tunes/main.swift
+++ b/Sources/tunes/main.swift
@@ -1,0 +1,10 @@
+//
+//  main.swift
+//  iTunesJson
+//
+//  Created by Greg Bolsinga on 12/22/24.
+//
+
+import iTunes
+
+await TunesCommand.go(CommandLine.arguments)


### PR DESCRIPTION
this way the bundled app can call any of the sub commands in the future.

the go() is to workaround https://github.com/apple/swift-argument-parser/issues/688