### PR TITLE
Add Patch/Patchable.trackCorrections

### DIFF
--- a/Sources/iTunes/Patch.swift
+++ b/Sources/iTunes/Patch.swift
@@ -17,6 +17,7 @@ enum Patch: Sendable {
   case albums(AlbumPatchLookup)
   case missingTitleAlbums(AlbumMissingTitlePatchLookup)
   case trackCounts(AlbumTrackCountLookup)
+  case trackCorrections([TrackCorrection])
 }
 
 // This will make a Dictionary<Key, Value> into Array<Key> where each Array
@@ -65,6 +66,8 @@ extension Patch: CustomStringConvertible {
     case .missingTitleAlbums(let items):
       return (try? (try? items.jsonData())?.asUTF8String()) ?? ""
     case .trackCounts(let items):
+      return (try? (try? items.jsonData())?.asUTF8String()) ?? ""
+    case .trackCorrections(let items):
       return (try? (try? items.jsonData())?.asUTF8String()) ?? ""
     }
   }

--- a/Sources/iTunes/Repair/Patchable.swift
+++ b/Sources/iTunes/Repair/Patchable.swift
@@ -12,4 +12,5 @@ enum Patchable: String, CaseIterable {
   case albums
   case missingTitleAlbums
   case trackCounts
+  case trackCorrections
 }

--- a/Sources/iTunes/Repair/RepairCommand.swift
+++ b/Sources/iTunes/Repair/RepairCommand.swift
@@ -15,6 +15,18 @@ extension Dictionary where Key: Codable & Comparable, Value: Codable & Comparabl
   }
 }
 
+extension Array where Element: Codable {
+  static fileprivate func load(from url: URL) throws -> Self {
+    try load(from: try Data(contentsOf: url, options: .mappedIfSafe))
+  }
+
+  static fileprivate func load(from data: Data) throws -> Self {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try decoder.decode(Self.self, from: data)
+  }
+}
+
 extension AlbumMissingTitlePatchLookup {
   static fileprivate func load(from url: URL) throws -> Self {
     try load(from: try Data(contentsOf: url, options: .mappedIfSafe))
@@ -50,6 +62,8 @@ extension Patchable {
       Patch.missingTitleAlbums(try AlbumMissingTitlePatchLookup.load(from: fileURL))
     case .trackCounts:
       Patch.trackCounts(try AlbumTrackCountLookup.load(from: fileURL))
+    case .trackCorrections:
+      Patch.trackCorrections(try Array<TrackCorrection>.load(from: fileURL))
     }
   }
 }

--- a/Sources/iTunes/TrackCorrection.swift
+++ b/Sources/iTunes/TrackCorrection.swift
@@ -1,0 +1,65 @@
+//
+//  TrackCorrection.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 1/1/25.
+//
+
+import Foundation
+
+struct TrackCorrection: Codable, Comparable, Hashable, Sendable {
+  enum Property: Codable, Comparable, Hashable, Sendable {
+    case albumTitle(SortableName)
+    case trackCount(Int)
+  }
+
+  let songArtistAlbum: SongArtistAlbum
+  let correction: Property
+
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    if lhs.songArtistAlbum == rhs.songArtistAlbum {
+      switch (lhs.correction, rhs.correction) {
+      case (.albumTitle(let lht), .albumTitle(let rht)):
+        return lht < rht
+      case (.trackCount(let lhc), .trackCount(let rhc)):
+        return lhc < rhc
+      default:
+        return false
+      }
+    }
+    return lhs.songArtistAlbum < rhs.songArtistAlbum
+  }
+}
+
+extension SongArtistAlbum {
+  fileprivate func matchesExcludingAlbumTitle(_ other: SongArtistAlbum) -> Bool {
+    songArtist == other.songArtist
+  }
+}
+
+extension TrackCorrection {
+  func matches(_ other: SongArtistAlbum) -> Bool {
+    switch correction {
+    case .albumTitle(_):
+      songArtistAlbum.matchesExcludingAlbumTitle(other)
+    case .trackCount(_):
+      songArtistAlbum == other
+    }
+  }
+}
+
+extension Collection where Element == TrackCorrection {
+  func matches(_ other: SongArtistAlbum) -> [Element] {
+    self.filter { $0.matches(other) }
+  }
+}
+
+extension TrackCorrection: CustomStringConvertible {
+  var description: String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    guard let data = try? encoder.encode(self) else { return "" }
+    return (try? data.asUTF8String()) ?? ""
+  }
+}


### PR DESCRIPTION
This is to be used when it is hard to get "the truth" from the current data. The first example is that Poster Childern "Grand Bargain! " album (note the '!' and ' ') and the single (first imported as "Grand Bargain!") are "similar" (since those two characters will be stripped). We need a "is equal" code path.

Additionally, this does not lend itself to a "the current data from iTunes is truth, figure it out" style of fix. This is because of the "isSimilar" code path.

Just hand-build TrackCorrection data. The TrackCorrection.Property enum may be added to to add more hand done corrections. This may be useful in the future.