### PR TITLE
backup now has an optional tagPrefix

### DIFF
--- a/Sources/iTunes/BackupCommand.swift
+++ b/Sources/iTunes/BackupCommand.swift
@@ -112,8 +112,9 @@ struct BackupCommand: AsyncParsableCommand {
   )
   var fileName: String?
 
-  @Option(help: "The prefix to use for the git tags.") var tagPrefix: String = BackupContext
-    .defaultTag
+  @Option(
+    help: "The prefix to use for the git tags. If not set, will try to find most recent tag prefix."
+  ) var tagPrefix: String?
 
   /// Outputfile where data will be writen, if outputDirectory is not specified.
   private var outputFile: URL? {

--- a/Sources/iTunes/BackupContext.swift
+++ b/Sources/iTunes/BackupContext.swift
@@ -6,11 +6,20 @@
 //
 
 import Foundation
+import GitLibrary
 
 struct BackupContext: Sendable {
   static let defaultTag = "iTunes"
 
   let branch: String
-  let tagPrefix: String
+  let tagPrefix: String?
   let version: String
+
+  func tag(_ git: Git) async throws -> String {
+    if let tagPrefix { return tagPrefix }
+    guard let currentPrefix = try await git.describeTag()?.tagPrefix() else {
+      return Self.defaultTag
+    }
+    return currentPrefix
+  }
 }

--- a/Sources/iTunes/GitBackupWriter.swift
+++ b/Sources/iTunes/GitBackupWriter.swift
@@ -77,9 +77,10 @@ struct GitBackupWriter: DestinationFileWriting {
     let git = outputFile.parentDirectoryGit
 
     try await git.validateAndCheckout(branch: context.branch)
+    let tagPrefix = try await context.tag(git)
     try await fileWriter.write(data: data)
 
     try await git.addCommitTagPush(
-      filename: outputFile.filename, tagPrefix: context.tagPrefix, version: context.version)
+      filename: outputFile.filename, tagPrefix: tagPrefix, version: context.version)
   }
 }


### PR DESCRIPTION
if it is not set, it will read the most recent tag and use that. This will allow it so that the LaunchAgent plist does not have to be updated each time the git repository version changes!