### PR TITLE
More criteria for non SQL encodable tracks

### DIFF
--- a/Sources/iTunes/Track+SQLEncodable.swift
+++ b/Sources/iTunes/Track+SQLEncodable.swift
@@ -23,6 +23,13 @@ extension Track {
     return tVShow
   }
 
+  fileprivate var isRemoteNoKindNoTime: Bool {
+    guard kind == nil else { return false }
+    guard let totalTime, totalTime == 0 else { return false }
+    guard let trackType, trackType == "Remote" else { return false }
+    return true
+  }
+
   var isSQLEncodable: Bool {
     guard !isPodcast else { return false }
     guard !isVoiceMemo else { return false }
@@ -38,6 +45,7 @@ extension Track {
     guard !kind.contains("internet audio stream") else { return false }
     guard kind != "quicktime movie file" else { return false }
     guard artistName != nil else { return false }
+    guard !isRemoteNoKindNoTime else { return false }
 
     return true
   }


### PR DESCRIPTION
- there are 2 "digital booklets" in the data that do not have a kind (they eventually become PDF Documents). They have no kind, they have no time, and they are trackType "Remote". No other files match this criteria, so let's not encode those types.