### PR TITLE
Rename to SongIntCorrection

### DIFF
--- a/Sources/iTunes/Album+Changes.swift
+++ b/Sources/iTunes/Album+Changes.swift
@@ -7,6 +7,16 @@
 
 import Foundation
 
+typealias SongTrackNumber = SongIntCorrection
+
+extension SongTrackNumber {
+  init(song: SongArtistAlbum, trackNumber: Int?) {
+    self.init(song: song, value: trackNumber)
+  }
+
+  var trackNumber: Int? { value }
+}
+
 extension Track {
   private var isCompilation: Bool {
     guard let compilation else { return false }

--- a/Sources/iTunes/SongIntCorrection.swift
+++ b/Sources/iTunes/SongIntCorrection.swift
@@ -1,5 +1,5 @@
 //
-//  SongTrackNumber.swift
+//  SongIntCorrection.swift
 //  itunes_json
 //
 //  Created by Greg Bolsinga on 1/2/25.
@@ -7,25 +7,25 @@
 
 import Foundation
 
-struct SongTrackNumber: Codable, Comparable, Hashable, Sendable {
+struct SongIntCorrection: Codable, Comparable, Hashable, Sendable {
   let song: SongArtistAlbum
-  let trackNumber: Int?
+  let value: Int?
 
   static func < (lhs: Self, rhs: Self) -> Bool {
     if lhs.song == rhs.song {
-      if let lhNumber = lhs.trackNumber {
-        if let rhNumber = rhs.trackNumber {
-          return lhNumber < rhNumber
+      if let lhValue = lhs.value {
+        if let rhValue = rhs.value {
+          return lhValue < rhValue
         }
         return false
       }
-      return rhs.trackNumber == nil
+      return rhs.value == nil
     }
     return lhs.song < rhs.song
   }
 }
 
-extension SongTrackNumber: CustomStringConvertible {
+extension SongIntCorrection: CustomStringConvertible {
   var description: String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys]


### PR DESCRIPTION
Add a typealias for the old name and API. The intent of this change is to re-use this for patching years, which are also Ints.