### PR TITLE
SongArtist now deals with SortableName

### DIFF
--- a/Sources/iTunes/Song+Changes.swift
+++ b/Sources/iTunes/Song+Changes.swift
@@ -8,9 +8,13 @@
 import Foundation
 
 extension Track {
+  fileprivate var sortableSongName: SortableName {
+    SortableName(name: name, sorted: sortName ?? "")
+  }
+
   var songArtist: SongArtist? {
     guard let artistName else { return nil }
-    return SongArtist(song: name, artist: artistName.name)
+    return SongArtist(song: sortableSongName, artist: artistName)
   }
 
   var songArtistAlbum: SongArtistAlbum? {

--- a/Sources/iTunes/SongArtist.swift
+++ b/Sources/iTunes/SongArtist.swift
@@ -8,14 +8,35 @@
 import Foundation
 
 struct SongArtist: Codable, Comparable, Hashable, Sendable {
-  let song: String
-  let artist: String
+  let song: SortableName
+  let artist: SortableName
 
   static func < (lhs: SongArtist, rhs: SongArtist) -> Bool {
     if lhs.song == rhs.song {
       return lhs.artist < rhs.artist
     }
     return lhs.song < rhs.song
+  }
+
+  init(song: SortableName, artist: SortableName) {
+    self.song = song
+    self.artist = artist
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    if let string = try? container.decode(String.self, forKey: .song) {
+      self.song = SortableName(name: string)
+    } else {
+      self.song = try container.decode(SortableName.self, forKey: .song)
+    }
+
+    if let string = try? container.decode(String.self, forKey: .artist) {
+      self.artist = SortableName(name: string)
+    } else {
+      self.artist = try container.decode(SortableName.self, forKey: .artist)
+    }
   }
 }
 

--- a/Tests/iTunes/SongArtistDecodeTests.swift
+++ b/Tests/iTunes/SongArtistDecodeTests.swift
@@ -15,7 +15,21 @@ struct SongArtistDecodeTests {
     let json = "{ \"artist\" : \"Greg Bolsinga\", \"song\" : \"The Ballad of the Coder\" }"
     let decoder = JSONDecoder()
     let songArtist = try decoder.decode(SongArtist.self, from: json.data(using: .utf8)!)
-    #expect(songArtist.artist == "Greg Bolsinga")
-    #expect(songArtist.song == "The Ballad of the Coder")
+    #expect(songArtist.artist.name == "Greg Bolsinga")
+    #expect(songArtist.artist.sorted.isEmpty)
+    #expect(songArtist.song.name == "The Ballad of the Coder")
+    #expect(songArtist.song.sorted.isEmpty)
+  }
+
+  @Test func newformat() async throws {
+    let json =
+      "{ \"artist\" : { \"name\" :\"Greg Bolsinga\", \"sorted\" :\"Bolsinga, Greg\" }, \"song\" : { \"name\" : \"The Ballad of the Coder\", \"sorted\" : \"Ballad of the Coder\" } }"
+
+    let decoder = JSONDecoder()
+    let songArtist = try decoder.decode(SongArtist.self, from: json.data(using: .utf8)!)
+    #expect(songArtist.artist.name == "Greg Bolsinga")
+    #expect(songArtist.artist.sorted == "Bolsinga, Greg")
+    #expect(songArtist.song.name == "The Ballad of the Coder")
+    #expect(songArtist.song.sorted == "Ballad of the Coder")
   }
 }


### PR DESCRIPTION
- Unfortunately it should have been this way out of the box.
- It makes the "old" JSON files that have repaired the repository obsolete. The Decoder for SongArtist has been updated to handle just Strings in the Data instead of SortableNames.