### PR TITLE
Always need to tag, even if there are no changes

### DIFF
--- a/Sources/iTunes/GitTagData.swift
+++ b/Sources/iTunes/GitTagData.swift
@@ -40,8 +40,8 @@ extension TagData {
 
     if hasChanges {
       try await git.commit("\(tag)\n\(version)")
-      try await git.tag(tag)
     }
+    try await git.tag(tag)
   }
 
   func write(to directory: URL, pathExtension: String) throws {


### PR DESCRIPTION
- This problem has been since iTunes-V6, but it was only discovered now. I think a repatch replay starting with V5 as a base is necessary.