### PR TITLE
Add Resources to iTunes Library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
   name: "itunes_json",
+  defaultLocalization: "en",
   platforms: [
     .macOS(.v15),
     .iOS(.v18),
@@ -24,6 +25,7 @@ let package = Package(
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "GitLibrary", package: "GitLibrary"),
       ],
+      resources: [.process("Resources/Localizable.xcstrings")],
       plugins: [.plugin(name: "PackageBuildInfoPlugin", package: "PackageBuildInfo")]),
     .testTarget(name: "iTunesTests", dependencies: ["iTunes"]),
     .executableTarget(name: "tunes", dependencies: [.byName(name: "iTunes")]),

--- a/Sources/iTunes/Program.swift
+++ b/Sources/iTunes/Program.swift
@@ -3,8 +3,8 @@ import Foundation
 
 public struct Program: AsyncParsableCommand {
   public static let configuration = CommandConfiguration(
-    commandName: "tunes",
-    abstract: "A tool for working with iTunes data.",
+    commandName: String(localized: "tunes", bundle: .module),
+    abstract: String(localized: "A tool for working with iTunes data.", bundle: .module),
     version: iTunesVersion,
     subcommands: [BackupCommand.self, PatchCommand.self, RepairCommand.self, BatchCommand.self],
     defaultSubcommand: BackupCommand.self

--- a/Sources/iTunes/Resources/Localizable.xcstrings
+++ b/Sources/iTunes/Resources/Localizable.xcstrings
@@ -1,0 +1,12 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "A tool for working with iTunes data." : {
+
+    },
+    "tunes" : {
+
+    }
+  },
+  "version" : "1.0"
+}


### PR DESCRIPTION
It just has localized strings for the main Program right now. This is basically just a start so Swift Package Manager has the .module symbol for Logging. That will come in a subsequent diff.