### PR TITLE
Add StructuredTag

### DIFF
--- a/Sources/iTunes/String+Tags.swift
+++ b/Sources/iTunes/String+Tags.swift
@@ -9,6 +9,34 @@ import Foundation
 import RegexBuilder
 
 extension String {
+  var structuredTag: StructuredTag? {
+    guard let (prefix, stamp) = tagPrefixAndStamp else { return nil }
+    guard let (root, version) = prefix.tagVersion else { return nil }
+    return StructuredTag(root: root, version: version, stamp: stamp)
+  }
+
+  var tagVersion: (String, Int)? {
+    let regex = Regex {
+      Capture { OneOrMore { .word } }
+      ChoiceOf {
+        "-"
+        "."
+      }
+      OneOrMore { .word }
+      TryCapture {
+        OneOrMore { .digit }
+      } transform: {
+        Int($0)
+      }
+    }
+    .repetitionBehavior(.reluctant)
+
+    if let match = try? regex.wholeMatch(in: self) {
+      return (String(match.output.1), match.output.2)
+    }
+    return nil
+  }
+
   var tagPrefixAndStamp: (String, String)? {
     let regex = Regex {
       Capture {

--- a/Sources/iTunes/StructuredTag.swift
+++ b/Sources/iTunes/StructuredTag.swift
@@ -1,0 +1,28 @@
+//
+//  StructuredTag.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 1/7/25.
+//
+
+import Foundation
+
+struct StructuredTag: Comparable, CustomStringConvertible {
+  let root: String  // "iTunes" from iTunes-V12-2025-01-01
+  let version: Int  // "12" from iTunes-V12-2025-01-01
+  let stamp: String  // "2025-01-01" from iTunes-V12-2025-01-01
+
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    if lhs.root != rhs.root {
+      return lhs.root < rhs.root
+    }
+    if lhs.version != rhs.version {
+      return lhs.version < rhs.version
+    }
+    return lhs.stamp < rhs.stamp
+  }
+
+  var description: String {
+    "\(root)-V\(version)-\(stamp)"
+  }
+}

--- a/Tests/iTunes/StructuredTagTests.swift
+++ b/Tests/iTunes/StructuredTagTests.swift
@@ -1,0 +1,31 @@
+//
+//  StructuredTagTests.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 1/7/25.
+//
+
+import Testing
+
+@testable import iTunes
+
+struct StructuredTagTests {
+  @Test func description() async throws {
+    #expect(
+      StructuredTag(
+        root: "aRoot", version: 33, stamp: "2025-01-07.23"
+      ).description == "aRoot-V33-2025-01-07.23")
+  }
+
+  @Test func comparisons() async throws {
+    let tags = [
+      StructuredTag(root: "iTunes", version: 1, stamp: "2006-01-01"),
+      StructuredTag(root: "iTunes", version: 8, stamp: "2006-01-01"),
+      StructuredTag(root: "iTunes", version: 8, stamp: "2006-01-01.01"),
+      StructuredTag(root: "iTunes", version: 9, stamp: "2006-01-02"),
+      StructuredTag(root: "iTunes", version: 10, stamp: "2006-01-02"),
+    ]
+
+    #expect(tags.shuffled().sorted() == tags)
+  }
+}

--- a/Tests/iTunes/TagTests.swift
+++ b/Tests/iTunes/TagTests.swift
@@ -150,4 +150,39 @@ struct TagTests {
   @Test func bad() throws {
     #expect("iTunes-2024-05-12-empty.01-empty".tagPrefixAndStamp == nil)
   }
+
+  @Test func standardTagVersion() async throws {
+    #expect(try #require("iTunes-V1".tagVersion) == ("iTunes", 1))
+    #expect(try #require("iTunes.V1".tagVersion) == ("iTunes", 1))
+    #expect(try #require("iTunes-V10".tagVersion) == ("iTunes", 10))
+    #expect(try #require("iTunes.V10".tagVersion) == ("iTunes", 10))
+    #expect(try #require("iTunes-A10".tagVersion) == ("iTunes", 10))
+    #expect(try #require("iTunes.A10".tagVersion) == ("iTunes", 10))
+    #expect(try #require("iTunes.artists1".tagVersion) == ("iTunes", 1))
+  }
+
+  @Test func invalidTagVersion() async throws {
+    #expect("iTunes".tagVersion == nil)
+    #expect("iTunes1".tagVersion == nil)
+    #expect("iTunes.1".tagVersion == nil)
+    #expect("iTunes-1".tagVersion == nil)
+    #expect("iTunesV1".tagVersion == nil)
+    #expect("iTunes.A".tagVersion == nil)
+    #expect("iTunes-A".tagVersion == nil)
+    #expect("iTunes.1A".tagVersion == nil)
+    #expect("iTunes-1A".tagVersion == nil)
+    #expect("iTunes.1artists".tagVersion == nil)
+  }
+
+  @Test func fullVersion() async throws {
+    #expect(
+      try #require("iTunes-V10-2025-01-07".structuredTag)
+        == StructuredTag(root: "iTunes", version: 10, stamp: "2025-01-07"))
+    #expect(
+      try #require("iTunes-V10-2025-01-07.01".structuredTag)
+        == StructuredTag(root: "iTunes", version: 10, stamp: "2025-01-07.01"))
+    #expect("iTunes-V10-2025-01-07.empty".structuredTag == nil)
+    #expect("iTunes.artists-2025-01-07".structuredTag == nil)
+    #expect("iTunes-2006-01-01".structuredTag == nil)
+  }
 }


### PR DESCRIPTION
- add a String.structuredTag property that will parse the string with RegexBuilder to get the tag version in a sortable struct.
- this will allow "heterogeneous" lists of tags to be constructed and sorted to workaround the existing results of the bug fixed by #596.