### PR TITLE
Add stampOrderedMatching

### DIFF
--- a/Sources/iTunes/Array+TagFilter.swift
+++ b/Sources/iTunes/Array+TagFilter.swift
@@ -7,8 +7,22 @@
 
 import Foundation
 
+extension Array where Element == StructuredTag {
+  fileprivate var stampOrderedMatching: [Element] {
+    self.reduce(into: [String: [Element]]()) {
+      var tags = $0[$1.stamp] ?? []
+      tags.append($1)
+      $0[$1.stamp] = tags
+    }.compactMap { $0.value.sorted().last }.sorted()
+  }
+}
+
 extension Array where Element == String {
   func orderedMatching(tagPrefix: String) -> [String] {
     self.filter { $0.matchingFormattedTag(prefix: tagPrefix) }.sorted()
+  }
+
+  var stampOrderedMatching: [Element] {
+    self.compactMap { $0.structuredTag }.stampOrderedMatching.map { $0.description }
   }
 }

--- a/Tests/iTunes/TagListExtractionTests.swift
+++ b/Tests/iTunes/TagListExtractionTests.swift
@@ -31,6 +31,11 @@ struct TagListExtractionTests {
     #expect(result[1] == tags[1])
     #expect(result[2] == tags[2])
     #expect(result[3] == tags[4])
+
+    let stampedResult = tags.shuffled().stampOrderedMatching
+
+    #expect(result.count == 4)
+    #expect(result == stampedResult)
   }
 
   @Test func assortedPrefixes_ordered() async throws {
@@ -84,15 +89,15 @@ struct TagListExtractionTests {
     #expect(!tags.isEmpty)
     #expect(tags.count == 14)
 
-    let result = tags.shuffled().orderedMatching(tagPrefix: "iTunes-V12")
+    let result = tags.shuffled().stampOrderedMatching
 
-    #expect(result.count != 6)
+    #expect(result.count == 6)
 
-    #expect(result[0] != tags[5])
-    #expect(result[1] != tags[6])
-    //    #expect(result[2] == tags[7])
-    //    #expect(result[3] == tags[8])
-    //    #expect(result[4] == tags[12])
-    //    #expect(result[5] == tags[13])
+    #expect(result[0] == tags[5])
+    #expect(result[1] == tags[6])
+    #expect(result[2] == tags[7])
+    #expect(result[3] == tags[8])
+    #expect(result[4] == tags[12])
+    #expect(result[5] == tags[13])
   }
 }


### PR DESCRIPTION
- it will use the stamp to order things. 
-- if there are multiple items with the same stamp, it will use the last versioned one
- it also just happens to work the same as the prefixed version. it also doesn't need a prefix to work!