### PR TITLE
Add TagFilter

### DIFF
--- a/Sources/iTunes/Batch/BatchCommand.swift
+++ b/Sources/iTunes/Batch/BatchCommand.swift
@@ -26,6 +26,9 @@ struct BatchCommand: AsyncParsableCommand {
   @Flag(help: "Lax database schema table constraints")
   var laxSchema: [SchemaFlag] = []
 
+  @Flag(help: "How to filter git tags. Default is .ordered")
+  var tagFilter: TagFilter = .ordered
+
   /// Git Directory to read and write data from.
   @Option(
     help: "The path for the git directory to work with.",
@@ -61,7 +64,7 @@ struct BatchCommand: AsyncParsableCommand {
 
   func run() async throws {
     let configuration = GitTagData.Configuration(
-      directory: gitDirectory, tagPrefix: tagPrefix, fileName: Self.fileName)
+      directory: gitDirectory, tagPrefix: tagPrefix, fileName: Self.fileName, tagFilter: tagFilter)
     try await batch.build(
       configuration, outputDirectory: outputDirectory,
       schemaOptions: laxSchema.schemaOptions)

--- a/Sources/iTunes/Patch/PatchCommand.swift
+++ b/Sources/iTunes/Patch/PatchCommand.swift
@@ -15,6 +15,9 @@ struct PatchCommand: AsyncParsableCommand {
   /// Input source type.
   @Flag(help: "Repairable type to build.") var repairable: Repairable = .artists
 
+  @Flag(help: "How to filter git tags. Default is .ordered")
+  var tagFilter: TagFilter = .ordered
+
   /// Git Directory to read and write data from.
   @Option(
     help: "The path for the git directory to work with.",
@@ -38,7 +41,8 @@ struct PatchCommand: AsyncParsableCommand {
 
   func run() async throws {
     let configuration = GitTagData.Configuration(
-      directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: PatchCommand.fileName)
+      directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: PatchCommand.fileName,
+      tagFilter: tagFilter)
     print(try await repairable.gather(configuration, correction: correction))
   }
 }

--- a/Sources/iTunes/Repair/RepairCommand.swift
+++ b/Sources/iTunes/Repair/RepairCommand.swift
@@ -96,6 +96,9 @@ struct RepairCommand: AsyncParsableCommand {
   /// Input source type.
   @Flag(help: "Patchable type to build.") var patchable: Patchable = .artists
 
+  @Flag(help: "How to filter git tags. Default is .ordered")
+  var tagFilter: TagFilter = .ordered
+
   /// Git Directory to read and write data from.
   @Option(
     help: "The path for the git directory to work with.",
@@ -139,12 +142,14 @@ struct RepairCommand: AsyncParsableCommand {
     let patch = try patchable.createPatch(patchURL)
 
     let sourceConfiguration = GitTagData.Configuration(
-      directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: Self.fileName)
+      directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: Self.fileName,
+      tagFilter: tagFilter)
 
     let destinationBranch = destinationBranch ?? patchable.rawValue
 
     let destinationConfiguration = GitTagData.Configuration(
-      directory: gitDirectory, branch: destinationBranch, fileName: Self.fileName)
+      directory: gitDirectory, branch: destinationBranch, fileName: Self.fileName,
+      tagFilter: tagFilter)
 
     try await patch.patch(
       sourceConfiguration: sourceConfiguration,

--- a/Sources/iTunes/TagFilter.swift
+++ b/Sources/iTunes/TagFilter.swift
@@ -1,0 +1,15 @@
+//
+//  TagFilter.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 1/8/25.
+//
+
+import ArgumentParser
+
+enum TagFilter {
+  case ordered
+  case stamped
+}
+
+extension TagFilter: EnumerableFlag {}


### PR DESCRIPTION
The commands may set their tagFilter, and GitTagData will use that to choose the algorithm to filter the tags.