### PR TITLE
missing album titles patch file is an array.

### DIFF
--- a/Sources/iTunes/Patch.swift
+++ b/Sources/iTunes/Patch.swift
@@ -9,7 +9,6 @@ import Foundation
 
 typealias ArtistPatchLookup = [SortableName: SortableName]
 typealias AlbumPatchLookup = [AlbumArtistName: AlbumArtistName]
-typealias AlbumMissingTitlePatchLookup = [SongArtist: SortableName]
 typealias AlbumTrackCountLookup = [AlbumArtistName: Int]
 typealias SongTrackNumberLookup = [SongArtistAlbum: Int]
 typealias SongYearLookup = [SongArtistAlbum: Int]
@@ -17,7 +16,7 @@ typealias SongYearLookup = [SongArtistAlbum: Int]
 enum Patch: Sendable {
   case artists(ArtistPatchLookup)
   case albums(AlbumPatchLookup)
-  case missingTitleAlbums(AlbumMissingTitlePatchLookup)
+  case missingTitleAlbums([SongArtistAlbum])
   case trackCounts(AlbumTrackCountLookup)
   case trackCorrections([TrackCorrection])
   case trackNumbers(SongTrackNumberLookup)
@@ -35,17 +34,6 @@ extension Dictionary where Key: Codable & Comparable, Value: Codable & Comparabl
     encoder.dateEncodingStrategy = .iso8601
     let items = self.map { $0 }.sorted(by: { $0 < $1 }).flatMap { [$0.0, $0.1] }
     return try encoder.encode(items)
-  }
-}
-
-extension AlbumMissingTitlePatchLookup {
-  fileprivate func jsonData() throws -> Data {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    encoder.dateEncodingStrategy = .iso8601
-    // FIXME: It would be nice to have the dictionary self-sort, like the extension above.
-    // The problem is that the key/values are different types.
-    return try encoder.encode(self)
   }
 }
 

--- a/Sources/iTunes/Repair/RepairCommand.swift
+++ b/Sources/iTunes/Repair/RepairCommand.swift
@@ -27,18 +27,6 @@ extension Array where Element: Codable {
   }
 }
 
-extension AlbumMissingTitlePatchLookup {
-  static fileprivate func load(from url: URL) throws -> Self {
-    try load(from: try Data(contentsOf: url, options: .mappedIfSafe))
-  }
-
-  static fileprivate func load(from data: Data) throws -> Self {
-    let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .iso8601
-    return try decoder.decode(Self.self, from: data)
-  }
-}
-
 extension AlbumTrackCountLookup {
   static fileprivate func load(from url: URL) throws -> Self {
     try load(from: try Data(contentsOf: url, options: .mappedIfSafe))
@@ -71,7 +59,7 @@ extension Patchable {
     case .albums:
       Patch.albums(try AlbumPatchLookup.load(from: fileURL))
     case .missingTitleAlbums:
-      Patch.missingTitleAlbums(try AlbumMissingTitlePatchLookup.load(from: fileURL))
+      Patch.missingTitleAlbums(try Array<SongArtistAlbum>.load(from: fileURL))
     case .trackCounts:
       Patch.trackCounts(try AlbumTrackCountLookup.load(from: fileURL))
     case .trackCorrections:

--- a/Sources/iTunes/Track+Patch.swift
+++ b/Sources/iTunes/Track+Patch.swift
@@ -446,11 +446,18 @@ extension Array where Element == Track {
     }
   }
 
-  fileprivate func patchMissingAlbumTitles(_ lookup: AlbumMissingTitlePatchLookup, tag: String)
+  fileprivate func patchMissingAlbumTitles(_ items: [SongArtistAlbum], tag: String)
     throws
     -> [Track]
   {
-    self.map { track in
+    let lookup = items.reduce(
+      into: [SongArtist: SortableName](),
+      { partialResult, item in
+        guard let album = item.album else { return }
+        partialResult[item.songArtist] = album
+      })
+
+    return self.map { track in
       guard track.albumName == nil, let songArtist = track.songArtist,
         let title = lookup[songArtist]
       else { return track }


### PR DESCRIPTION
this way it can have stably sorted output. the dictionary was unable to sort nicely because the keys were not [String:Any].