### PR TITLE
When creating PreparedStatements return an Array

### DIFF
--- a/Sources/iTunes/Database+CreateTable.swift
+++ b/Sources/iTunes/Database+CreateTable.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+private enum CreateTableError: Error {
+  case tooManyStatements
+}
+
 protocol TableBuilder: Sendable {
   associatedtype Row: SQLBindableInsert & Hashable & Sendable
 
@@ -25,8 +29,8 @@ extension TableBuilder {
     return []
   }
 
-  func preparedStatement(using db: isolated Database) throws -> Database.PreparedStatement {
-    try Database.PreparedStatement(sql: Row.insertBinding, db: db)
+  func preparedStatements(using db: isolated Database) throws -> [Database.PreparedStatement] {
+    try Database.PreparedStatement.create(sql: Row.insertBinding, db: db)
   }
 }
 
@@ -48,7 +52,11 @@ extension Database {
     return try self.transaction { db in
       try db.execute(builder.schema(constraints: schemaConstraints))
 
-      let statement = try builder.preparedStatement(using: db)
+      let statements = try builder.preparedStatements(using: db)
+
+      guard statements.count == 1, let statement = statements.first else {
+        throw CreateTableError.tooManyStatements
+      }
 
       return try statement.executeAndClose(db) { statement, db in
         try builder.rows.reduce(into: [B.Row: Int64](minimumCapacity: builder.rows.count)) {

--- a/Sources/iTunes/Query/QueryCommand.swift
+++ b/Sources/iTunes/Query/QueryCommand.swift
@@ -31,6 +31,8 @@ extension GitTagData {
       guard !queryRows.isEmpty else { continue }
 
       for rows in queryRows {
+        guard !rows.isEmpty else { continue }
+
         if columns.isEmpty {
           columns = rows[0].keys.sorted()
           print((["tag"] + columns).joined(separator: "|"))

--- a/Sources/iTunes/Query/QueryCommand.swift
+++ b/Sources/iTunes/Query/QueryCommand.swift
@@ -9,7 +9,7 @@ import ArgumentParser
 import Foundation
 
 extension Database {
-  func executeAndClose(_ query: String) throws -> [Row] {
+  func executeAndClose(_ query: String) throws -> [[Row]] {
     let result = try execute(query: query)
     close()
     return result
@@ -27,19 +27,21 @@ extension GitTagData {
     var columns = [String]()
 
     for database in databases {
-      let rows = try await database.item.executeAndClose(query)
-      guard !rows.isEmpty else { continue }
+      let queryRows = try await database.item.executeAndClose(query)
+      guard !queryRows.isEmpty else { continue }
 
-      if columns.isEmpty {
-        columns = rows[0].keys.sorted()
-        print((["tag"] + columns).joined(separator: "|"))
-      }
+      for rows in queryRows {
+        if columns.isEmpty {
+          columns = rows[0].keys.sorted()
+          print((["tag"] + columns).joined(separator: "|"))
+        }
 
-      for row in rows {
-        let rowDescription = columns.reduce(into: [database.tag]) {
-          $0.append("\(row[$1] ?? .null)")
-        }.joined(separator: "|")
-        print(rowDescription)
+        for row in rows {
+          let rowDescription = columns.reduce(into: [database.tag]) {
+            $0.append("\(row[$1] ?? .null)")
+          }.joined(separator: "|")
+          print(rowDescription)
+        }
       }
     }
   }


### PR DESCRIPTION
- This makes all the logic of the callers handle the array of PreparedStatements. his is because the string passed in may be > 1 statement.
- The TableBuilding code fails if there is > 1 statement, since that code is specific.
- This change is mostly for QueryCommand, which will get a raw string to process.
- The implementation of PreparedStatement.create() **only** returns 1 statement right now. Next diff will fix that. This change is just for all the API scaffolding changes required.