### PR TITLE
Revert "When creating PreparedStatements return an Array (#630)"

### DIFF
--- a/Sources/iTunes/Query/QueryCommand.swift
+++ b/Sources/iTunes/Query/QueryCommand.swift
@@ -9,7 +9,7 @@ import ArgumentParser
 import Foundation
 
 extension Database {
-  func executeAndClose(_ query: String) throws -> [[Row]] {
+  func executeAndClose(_ query: String) throws -> [Row] {
     let result = try execute(query: query)
     close()
     return result
@@ -27,23 +27,19 @@ extension GitTagData {
     var columns = [String]()
 
     for database in databases {
-      let queryRows = try await database.item.executeAndClose(query)
-      guard !queryRows.isEmpty else { continue }
+      let rows = try await database.item.executeAndClose(query)
+      guard !rows.isEmpty else { continue }
 
-      for rows in queryRows {
-        guard !rows.isEmpty else { continue }
+      if columns.isEmpty {
+        columns = rows[0].keys.sorted()
+        print((["tag"] + columns).joined(separator: "|"))
+      }
 
-        if columns.isEmpty {
-          columns = rows[0].keys.sorted()
-          print((["tag"] + columns).joined(separator: "|"))
-        }
-
-        for row in rows {
-          let rowDescription = columns.reduce(into: [database.tag]) {
-            $0.append("\(row[$1] ?? .null)")
-          }.joined(separator: "|")
-          print(rowDescription)
-        }
+      for row in rows {
+        let rowDescription = columns.reduce(into: [database.tag]) {
+          $0.append("\(row[$1] ?? .null)")
+        }.joined(separator: "|")
+        print(rowDescription)
       }
     }
   }


### PR DESCRIPTION
This reverts commit d8199deec1613534d55f49556eb3ec91a47f478c.

This is because subsequent statements may depend upon previous statements and fail to compile. Therefore the subsequent statements should be prepared after the previous ones have executed!