### PR TITLE
Only use the TagFilter.stamped mode

### DIFF
--- a/Sources/iTunes/Array+TagFilter.swift
+++ b/Sources/iTunes/Array+TagFilter.swift
@@ -18,10 +18,6 @@ extension Array where Element == StructuredTag {
 }
 
 extension Array where Element == String {
-  func orderedMatching(tagPrefix: String) -> [String] {
-    self.filter { $0.matchingFormattedTag(prefix: tagPrefix) }.sorted()
-  }
-
   var stampOrderedMatching: [Element] {
     self.compactMap { $0.structuredTag }.stampOrderedMatching.map { $0.description }
   }

--- a/Sources/iTunes/Batch/BatchCommand.swift
+++ b/Sources/iTunes/Batch/BatchCommand.swift
@@ -26,9 +26,6 @@ struct BatchCommand: AsyncParsableCommand {
   @Flag(help: "Lax database schema table constraints")
   var laxSchema: [SchemaFlag] = []
 
-  @Flag(help: "How to filter git tags.")
-  var tagFilter: TagFilter = .ordered
-
   /// Git Directory to read and write data from.
   @Option(
     help: "The path for the git directory to work with.",
@@ -43,8 +40,6 @@ struct BatchCommand: AsyncParsableCommand {
     })
   )
   var gitDirectory: URL
-
-  @Option(help: "The prefix to use for the git tags.") var tagPrefix: String = "iTunes"
 
   /// Output Directory for batch results.
   @Option(
@@ -63,8 +58,7 @@ struct BatchCommand: AsyncParsableCommand {
   var outputDirectory: URL
 
   func run() async throws {
-    let configuration = GitTagData.Configuration(
-      directory: gitDirectory, tagPrefix: tagPrefix, fileName: Self.fileName, tagFilter: tagFilter)
+    let configuration = GitTagData.Configuration(directory: gitDirectory, fileName: Self.fileName)
     try await batch.build(
       configuration, outputDirectory: outputDirectory,
       schemaOptions: laxSchema.schemaOptions)

--- a/Sources/iTunes/GitTagData.swift
+++ b/Sources/iTunes/GitTagData.swift
@@ -39,34 +39,16 @@ extension Tag where Item == Data {
   }
 }
 
-extension TagFilter {
-  fileprivate func filter(tags: [String], prefix: String) -> [String] {
-    switch self {
-    case .ordered:
-      tags.orderedMatching(tagPrefix: prefix)
-    case .stamped:
-      tags.stampOrderedMatching
-    }
-  }
-}
-
 struct GitTagData {
   struct Configuration {
     let directory: URL
-    let tagPrefix: String
     let branch: String?
     let fileName: String
-    let tagFilter: TagFilter
 
-    init(
-      directory: URL, tagPrefix: String = "", branch: String? = nil, fileName: String,
-      tagFilter: TagFilter
-    ) {
+    init(directory: URL, branch: String? = nil, fileName: String) {
       self.directory = directory
-      self.tagPrefix = tagPrefix
       self.branch = branch
       self.fileName = fileName
-      self.tagFilter = tagFilter
     }
 
     var file: URL {
@@ -74,7 +56,7 @@ struct GitTagData {
     }
 
     func filter(tags: [String]) -> [String] {
-      tagFilter.filter(tags: tags, prefix: tagPrefix)
+      tags.stampOrderedMatching
     }
   }
 

--- a/Sources/iTunes/Patch/PatchCommand.swift
+++ b/Sources/iTunes/Patch/PatchCommand.swift
@@ -15,9 +15,6 @@ struct PatchCommand: AsyncParsableCommand {
   /// Input source type.
   @Flag(help: "Repairable type to build.") var repairable: Repairable = .artists
 
-  @Flag(help: "How to filter git tags.")
-  var tagFilter: TagFilter = .ordered
-
   /// Git Directory to read and write data from.
   @Option(
     help: "The path for the git directory to work with.",
@@ -33,16 +30,13 @@ struct PatchCommand: AsyncParsableCommand {
   )
   var gitDirectory: URL
 
-  @Option(help: "The prefix to use for the git tags.") var sourceTagPrefix: String = "iTunes"
-
   /// Optional corrections to use when creating this patch.
   @Option(help: "The corrections to apply when creating this patch (as a JSON string).")
   var correction: String = ""
 
   func run() async throws {
     let configuration = GitTagData.Configuration(
-      directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: PatchCommand.fileName,
-      tagFilter: tagFilter)
+      directory: gitDirectory, fileName: PatchCommand.fileName)
     print(try await repairable.gather(configuration, correction: correction))
   }
 }

--- a/Sources/iTunes/Query/QueryCommand.swift
+++ b/Sources/iTunes/Query/QueryCommand.swift
@@ -61,9 +61,6 @@ struct QueryCommand: AsyncParsableCommand {
   @Flag(help: "Lax database schema table constraints")
   var laxSchema: [SchemaFlag] = []
 
-  @Flag(help: "How to filter git tags.")
-  var tagFilter: TagFilter = .ordered
-
   /// Git Directory to read and write data from.
   @Option(
     help: "The path for the git directory to work with.",
@@ -79,8 +76,6 @@ struct QueryCommand: AsyncParsableCommand {
   )
   var gitDirectory: URL
 
-  @Option(help: "The prefix to use for the git tags.") var tagPrefix: String = "iTunes"
-
   @Argument(help: "The SQL query to run.") var query: String = ""
 
   func validate() throws {
@@ -90,8 +85,7 @@ struct QueryCommand: AsyncParsableCommand {
   }
 
   func run() async throws {
-    let configuration = GitTagData.Configuration(
-      directory: gitDirectory, tagPrefix: tagPrefix, fileName: Self.fileName, tagFilter: tagFilter)
+    let configuration = GitTagData.Configuration(directory: gitDirectory, fileName: Self.fileName)
     try await GitTagData(configuration: configuration).execute(
       query: query, schemaOptions: laxSchema.schemaOptions)
   }

--- a/Sources/iTunes/Repair/RepairCommand.swift
+++ b/Sources/iTunes/Repair/RepairCommand.swift
@@ -62,9 +62,6 @@ struct RepairCommand: AsyncParsableCommand {
   /// Input source type.
   @Flag(help: "Patchable type to build.") var patchable: Patchable = .artists
 
-  @Flag(help: "How to filter git tags.")
-  var tagFilter: TagFilter = .ordered
-
   /// Git Directory to read and write data from.
   @Option(
     help: "The path for the git directory to work with.",
@@ -87,8 +84,6 @@ struct RepairCommand: AsyncParsableCommand {
   )
   var patchURL: URL
 
-  @Option(help: "The prefix to use for the source git tags.") var sourceTagPrefix: String = "iTunes"
-
   @Option(
     help:
       "The string to append to the sourceTagPrefix for the destination git branch."
@@ -98,24 +93,16 @@ struct RepairCommand: AsyncParsableCommand {
   @Option(help: "The destination git branch. Defaults to the patchable type name.")
   var destinationBranch: String?
 
-  func validate() throws {
-    if sourceTagPrefix == destinationTagPrefix {
-      throw ValidationError("Source and Destination Tags must be different.")
-    }
-  }
-
   func run() async throws {
     let patch = try patchable.createPatch(patchURL)
 
     let sourceConfiguration = GitTagData.Configuration(
-      directory: gitDirectory, tagPrefix: sourceTagPrefix, fileName: Self.fileName,
-      tagFilter: tagFilter)
+      directory: gitDirectory, fileName: Self.fileName)
 
     let destinationBranch = destinationBranch ?? patchable.rawValue
 
     let destinationConfiguration = GitTagData.Configuration(
-      directory: gitDirectory, branch: destinationBranch, fileName: Self.fileName,
-      tagFilter: tagFilter)
+      directory: gitDirectory, branch: destinationBranch, fileName: Self.fileName)
 
     try await patch.patch(
       sourceConfiguration: sourceConfiguration,

--- a/Sources/iTunes/String+Tags.swift
+++ b/Sources/iTunes/String+Tags.swift
@@ -79,14 +79,6 @@ extension String {
     tagPrefixAndStamp?.0
   }
 
-  func matchingFormattedTag(prefix: String) -> Bool {
-    guard !prefix.isEmpty else { return false }
-
-    guard let existingPrefix = tagPrefix else { return false }
-
-    return existingPrefix == prefix
-  }
-
   func replacePrefix(newPrefix: String) -> String? {
     guard let prefix = tagPrefix else { return nil }
 

--- a/Tests/iTunes/TagListExtractionTests.swift
+++ b/Tests/iTunes/TagListExtractionTests.swift
@@ -23,7 +23,7 @@ struct TagListExtractionTests {
     #expect(!tags.isEmpty)
     #expect(tags.count == 6)
 
-    let result = tags.shuffled().orderedMatching(tagPrefix: "iTunes-V12")
+    let result = tags.shuffled().stampOrderedMatching
 
     #expect(result.count == 4)
 
@@ -31,41 +31,6 @@ struct TagListExtractionTests {
     #expect(result[1] == tags[1])
     #expect(result[2] == tags[2])
     #expect(result[3] == tags[4])
-
-    let stampedResult = tags.shuffled().stampOrderedMatching
-
-    #expect(result.count == 4)
-    #expect(result == stampedResult)
-  }
-
-  @Test func assortedPrefixes_ordered() async throws {
-    let tags = """
-      iTunes-2006-01-01
-      iTunes.artists-2006-01-01
-      iTunes-V2-2006-01-01
-      iTunes-V3-2006-01-01
-      iTunes-V4-2006-01-01
-      iTunes-V5-2006-01-01
-      iTunes-V6-2006-02-01
-      iTunes-V7-2006-03-01
-      iTunes-V8-2006-04-01
-      iTunes-V9-2006-05-01
-      iTunes-V10-2006-05-01
-      iTunes-V11-2006-05-01
-      iTunes-V12-2006-05-01
-      iTunes-V12-2006-06-01
-      """.split(separator: "\n").map { String($0) }
-
-    #expect(!tags.isEmpty)
-    #expect(tags.count == 14)
-
-    let result = tags.shuffled().orderedMatching(tagPrefix: "iTunes-V12")
-
-    #expect(result.count == 2)
-
-    for index in 0..<result.count {
-      #expect(result[index] == tags[index + 12])
-    }
   }
 
   @Test func assortedPrefixes_date() async throws {

--- a/Tests/iTunes/TagTests.swift
+++ b/Tests/iTunes/TagTests.swift
@@ -103,26 +103,6 @@ struct TagTests {
     #expect("2024-10-25".tagPrefixAndStamp == nil)
   }
 
-  @Test func matchingEmpty() throws {
-    #expect(!"tag-2024-12-05".matchingFormattedTag(prefix: ""))
-  }
-
-  @Test func matchingInvalidPrefix() throws {
-    #expect(!"-2024-12-05".matchingFormattedTag(prefix: "tag"))
-  }
-
-  @Test func matchingNonConforming() throws {
-    #expect(!"xxxxx".matchingFormattedTag(prefix: "tag"))
-  }
-
-  @Test func matchingWrongPrefix() throws {
-    #expect(!"tag-2024-12-05".matchingFormattedTag(prefix: "x"))
-  }
-
-  @Test func matchingPrefix() throws {
-    #expect("tag-2024-12-05".matchingFormattedTag(prefix: "tag"))
-  }
-
   @Test func replaceInvalid() throws {
     #expect("-2024-12-05".replacePrefix(newPrefix: "X") == nil)
   }


### PR DESCRIPTION
- Also means that these commands no longer need to pass in a tagPrefix to look for.