### PR TITLE
Keep the Row in the column order returned

### DIFF
--- a/Sources/iTunes/Database.swift
+++ b/Sources/iTunes/Database.swift
@@ -36,7 +36,8 @@ typealias StatementHandle = OpaquePointer
 actor Database {
   typealias Value = Statement.Value
 
-  typealias Row = [String: Value]
+  typealias Column = (column: String, value: Value)
+  typealias Row = [Column]
 
   fileprivate struct Logging {
     let open: Logger
@@ -235,7 +236,8 @@ actor Database {
         if columnNames.count <= index {
           columnNames.append(try columnName(for: index))
         }
-        row[columnNames[Int(index)]] = try columnValue(for: index)
+        let column = Column(column: columnNames[Int(index)], value: try columnValue(for: index))
+        row.append(column)
       }
 
       return row

--- a/Sources/iTunes/Query/QueryCommand.swift
+++ b/Sources/iTunes/Query/QueryCommand.swift
@@ -33,14 +33,12 @@ extension GitTagData {
 
         var columns = [String]()
         if columns.isEmpty {
-          columns = rows[0].keys.sorted()
+          columns = rows[0].map { $0.column }
           print((["tag"] + columns).joined(separator: "|"))
         }
 
         for row in rows {
-          let rowDescription = columns.reduce(into: [database.tag]) {
-            $0.append("\(row[$1] ?? .null)")
-          }.joined(separator: "|")
+          let rowDescription = ([database.tag] + row.map { "\($0.value)" }).joined(separator: "|")
           print(rowDescription)
         }
       }


### PR DESCRIPTION
- Can add an adapter for a dictionary based row if needed in the future!
- This allows the query processed to declare the expected column order.