### PR TITLE
add option to serialize database queries

### DIFF
--- a/Sources/iTunes/GitTagData.swift
+++ b/Sources/iTunes/GitTagData.swift
@@ -44,11 +44,16 @@ struct GitTagData {
     let directory: URL
     let branch: String?
     let fileName: String
+    let serializeDatabaseQueries: Bool
 
-    init(directory: URL, branch: String? = nil, fileName: String) {
+    init(
+      directory: URL, branch: String? = nil, fileName: String,
+      serializeDatabaseQueries: Bool = false
+    ) {
       self.directory = directory
       self.branch = branch
       self.fileName = fileName
+      self.serializeDatabaseQueries = serializeDatabaseQueries
     }
 
     var file: URL {
@@ -60,7 +65,7 @@ struct GitTagData {
     }
   }
 
-  private let configuration: Configuration
+  let configuration: Configuration
   private let git: Git
 
   init(configuration: Configuration) throws {

--- a/Sources/iTunes/Query/QueryCommand.swift
+++ b/Sources/iTunes/Query/QueryCommand.swift
@@ -80,6 +80,12 @@ struct QueryCommand: AsyncParsableCommand {
   @Flag(help: "Lax database schema table constraints")
   var laxSchema: [SchemaFlag] = []
 
+  /// Should query run serially.
+  @Flag(
+    help:
+      "Run the query on each database serially. Some SQL may ATTACH a single database, so this would be required."
+  ) var serializeDatabaseQueries: Bool = false
+
   /// Git Directory to read and write data from.
   @Option(
     help: "The path for the git directory to work with.",
@@ -104,7 +110,9 @@ struct QueryCommand: AsyncParsableCommand {
   }
 
   func run() async throws {
-    let configuration = GitTagData.Configuration(directory: gitDirectory, fileName: Self.fileName)
+    let configuration = GitTagData.Configuration(
+      directory: gitDirectory, fileName: Self.fileName,
+      serializeDatabaseQueries: serializeDatabaseQueries)
     try await transform.query(
       query, configuration: configuration, schemaOptions: laxSchema.schemaOptions)
   }


### PR DESCRIPTION
- process the serialized database in tag order.
- This will allow queries that ATTACH another database to work properly, so it is an option that defaults to false.
- it does not seem ideal to put this in the Configuration, but it involves less piping of the Bool through the system...