### PR TITLE
Add DatabaseFormat.flat

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ The output of this program is also used as input to [web generator](https://gith
 
 These modes are useful when there is listening history in a git repository created by this program. It allows the data to be mined, create patches, and repair the data. Iterations over the data will allow it to populate the database tables with strict schema enabled.
 
-There is one database format.
+There are two database formats.
 - Normalized: It has four tables: artists, albums, songs, plays. They each reference each other via IDs. The intent is that an artist only appears once, etc.
+- Flat: It has a single table, which is all the tracks that are SQL encodable (aka music tracks), with the columns non unique. This will be useful for more data mining.
 
 ### patch
 This will create patch files for the repair tool to use. It makes the assumption that the current data found in the Music application is correct. It then will go through the backups in git history to find "patches" to tracks that are "similar".
@@ -44,6 +45,7 @@ This will iterate through a git repository with listening history and execute th
 
 - `raw` - This is the default, where the normalized database rows are just written to standard out.
 - `tracks` - This will attempt to transform the query result from the normalized database `tracks` view into `[Track]`. It will just emit these tracks as JSON.
+- `flat` - This will query the flat databases, written to standard out.
 
 ## Future
 Back up to a single already existing database file, instead of many snapshots of data. Music will only tell you the last time a song was played. This database will have all the times it was played. I have backup data dating to 01/01/2006 to work with.

--- a/Sources/iTunes/BackupCommand.swift
+++ b/Sources/iTunes/BackupCommand.swift
@@ -13,10 +13,12 @@ enum DestinationContext: EnumerableFlag {
   case json
   /// Emit JSON representing the Tracks and add to a git repository
   case jsonGit
-  /// Emit SQLite code that represents the Tracks.
+  /// Emit Normalized SQLite code that represents the Tracks.
   case sqlCode
-  /// Emit a sqlite3 database that represents the Tracks.
+  /// Emit a Normalized sqlite3 database that represents the Tracks.
   case db
+  /// Emit a Flat sqlite3 database that represents the Tracks.
+  case flat
 
   func context(outputFile: URL?, schemaOptions: SchemaOptions) throws -> Destination {
     enum DestinationError: Error {
@@ -47,6 +49,13 @@ enum DestinationContext: EnumerableFlag {
       case .standardOut, .update:
         throw DestinationError.noDBOutputFile
       }
+    case .flat:
+      switch output {
+      case .file(let outputFile):
+        return .db(.flat(FlatDatabaseContext(storage: .file(outputFile), loggingToken: nil)))
+      case .standardOut, .update:
+        throw DestinationError.noDBOutputFile
+      }
     }
   }
 
@@ -61,7 +70,7 @@ enum DestinationContext: EnumerableFlag {
       "json"
     case .sqlCode:
       "sql"
-    case .db:
+    case .db, .flat:
       "db"
     }
   }

--- a/Sources/iTunes/Batch/Batch.swift
+++ b/Sources/iTunes/Batch/Batch.swift
@@ -17,6 +17,8 @@ enum Batch: CaseIterable {
   case sql
   /// Normalized Database
   case db
+  /// Flat Database
+  case flat
 }
 
 extension Tag where Item == Data {
@@ -46,6 +48,9 @@ extension Batch {
               .normalized(
                 DatabaseContext(
                   storage: .memory, schemaOptions: schemaOptions, loggingToken: "batch-\(tag)")))
+          case .flat:
+            Destination.db(
+              .flat(FlatDatabaseContext(storage: .memory, loggingToken: "batch-\(tag)")))
           }
         }()
 
@@ -56,7 +61,7 @@ extension Batch {
       switch self {
       case .sql:
         "sql"
-      case .db:
+      case .db, .flat:
         "db"
       }
     }()

--- a/Sources/iTunes/DatabaseFormat.swift
+++ b/Sources/iTunes/DatabaseFormat.swift
@@ -9,12 +9,15 @@ import Foundation
 
 enum DatabaseFormat {
   case normalized(DatabaseContext)
+  case flat(FlatDatabaseContext)
 }
 
 extension DatabaseFormat {
   var storage: DatabaseStorage {
     switch self {
     case .normalized(let context):
+      context.storage
+    case .flat(let context):
       context.storage
     }
   }
@@ -52,11 +55,46 @@ extension Array where Element == Track {
   }
 }
 
+extension FlatDatabaseContext: FlatTracksDBEncoderContext {
+  var context: Database.Context {
+    Database.Context(storage: storage, loggingToken: loggingToken)
+  }
+}
+
+extension Array where Element == Track {
+  fileprivate func flatDatabase(_ context: FlatDatabaseContext) async throws -> Database {
+    let dbEncoder = try FlatTracksDBEncoder(context: context)
+    do {
+      try await dbEncoder.encode(tracks: self.filter { $0.isSQLEncodable })
+      return dbEncoder.db
+    } catch {
+      await dbEncoder.close()
+      throw error
+    }
+  }
+
+  fileprivate func flatDatabase(_ context: FlatDatabaseContext) async throws
+    -> Data
+  {
+    let db: Database = try await flatDatabase(context)
+    do {
+      let data = try await db.data()
+      await db.close()
+      return data
+    } catch {
+      await db.close()
+      throw error
+    }
+  }
+}
+
 extension DatabaseFormat {
   func database(tracks: [Track]) async throws -> Database {
     switch self {
     case .normalized(let context):
       try await tracks.database(context)
+    case .flat(let context):
+      try await tracks.flatDatabase(context)
     }
   }
 
@@ -64,6 +102,8 @@ extension DatabaseFormat {
     switch self {
     case .normalized(let context):
       try await tracks.database(context)
+    case .flat(let context):
+      try await tracks.flatDatabase(context)
     }
   }
 }

--- a/Sources/iTunes/FlatDatabaseContext.swift
+++ b/Sources/iTunes/FlatDatabaseContext.swift
@@ -1,0 +1,13 @@
+//
+//  FlatDatabaseContext.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 1/29/25.
+//
+
+import Foundation
+
+struct FlatDatabaseContext {
+  let storage: DatabaseStorage
+  let loggingToken: String?
+}

--- a/Sources/iTunes/FlatTrackRow.swift
+++ b/Sources/iTunes/FlatTrackRow.swift
@@ -1,0 +1,44 @@
+//
+//  FlatTrackRow.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 1/28/25.
+//
+
+import Foundation
+
+struct FlatTrackRow {
+  let track: Track
+
+  fileprivate var itunesid: String { String(track.persistentID) }
+  fileprivate var name: String { track.name }
+  fileprivate var sortname: String { track.sortName ?? "" }
+  fileprivate var artist: String { track.artist ?? "" }
+  fileprivate var sortartist: String { track.sortArtist ?? "" }
+  fileprivate var album: String { track.album ?? "" }
+  fileprivate var sortalbum: String { track.sortAlbum ?? "" }
+  fileprivate var tracknumber: Int { track.trackNumber ?? 0 }
+  fileprivate var trackcount: Int { track.trackCount ?? 0 }
+  fileprivate var disccount: Int { track.discCount ?? 0 }
+  fileprivate var discnumber: Int { track.discNumber ?? 0 }
+  fileprivate var year: Int { track.year ?? 0 }
+  fileprivate var duration: Int { track.totalTime ?? 0 }
+  fileprivate var dateadded: String { track.dateAddedISO8601 }
+  fileprivate var compilation: Int { (track.compilation ?? false) ? 1 : 0 }
+  fileprivate var composer: String { track.composer ?? "" }
+  fileprivate var datereleased: String { track.dateReleasedISO8601 }
+  fileprivate var comments: String { track.comments ?? "" }
+  fileprivate var playdate: String { track.datePlayedISO8601 }
+  fileprivate var playcount: Int { track.playCount ?? 0 }
+
+  var insert: Database.Statement {
+    """
+    INSERT INTO tracks (itunesid, name, sortname, artist, sortartist, album, sortalbum, tracknumber, trackcount, disccount, discnumber, year, duration, dateadded, compilation, composer, datereleased, comments, playdate, playcount)
+    VALUES (\(itunesid), \(name), \(sortname), \(artist), \(sortartist), \(album), \(sortalbum), \(tracknumber), \(trackcount), \(disccount), \(discnumber), \(year), \(duration), \(dateadded), \(compilation), \(composer), \(datereleased), \(comments), \(playdate), \(playcount));
+    """
+  }
+
+  static var insertStatement: Database.Statement {
+    FlatTrackRow(track: Track(name: "fake", persistentID: 0)).insert
+  }
+}

--- a/Sources/iTunes/FlatTracksDBEncoder.swift
+++ b/Sources/iTunes/FlatTracksDBEncoder.swift
@@ -1,0 +1,71 @@
+//
+//  FlatTracksDBEncoder.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 1/28/25.
+//
+
+import Foundation
+
+protocol FlatTracksDBEncoderContext {
+  var context: Database.Context { get }
+}
+
+struct FlatTracksDBEncoder<Context: FlatTracksDBEncoderContext> {
+  let db: Database
+
+  init(context: Context) throws {
+    self.db = try Database(context: context.context)
+  }
+
+  func encode(tracks: [Track]) async throws {
+    let rows = tracks.map { FlatTrackRow(track: $0) }
+
+    try await db.transaction { db in
+      try db.execute(schema)
+
+      let statement = try Database.PreparedStatement(sql: FlatTrackRow.insertStatement, db: db)
+
+      try statement.executeAndClose(db) { statement, db in
+        for row in rows {
+          try statement.bind(arguments: row.insert.parameters) { db.errorString }
+          try statement.execute { db.errorString }
+        }
+      }
+    }
+  }
+
+  func close() async {
+    await db.close()
+  }
+
+  func data() async throws -> Data {
+    try await db.data()
+  }
+
+  private var schema: String = """
+    CREATE TABLE tracks (
+      id INTEGER PRIMARY KEY,
+      itunesid TEXT NOT NULL,
+      name TEXT NOT NULL,
+      sortname TEXT NOT NULL DEFAULT '',
+      artist TEXT NOT NULL,
+      sortartist TEXT NOT NULL DEFAULT '',
+      album TEXT NOT NULL,
+      sortalbum TEXT NOT NULL DEFAULT '',
+      tracknumber INTEGER NOT NULL,
+      trackcount INTEGER NOT NULL,
+      disccount INTEGER NOT NULL,
+      discnumber INTEGER NOT NULL,
+      year INTEGER NOT NULL,
+      duration INTEGER NOT NULL,
+      dateadded TEXT NOT NULL,
+      compilation INTEGER NOT NULL,
+      composer TEXT NOT NULL DEFAULT '',
+      datereleased TEXT NOT NULL DEFAULT '',
+      comments TEXT NOT NULL DEFAULT '',
+      playdate TEXT NOT NULL,
+      playcount INTEGER NOT NULL
+    );
+    """
+}

--- a/Sources/iTunes/GitTagData+Databases.swift
+++ b/Sources/iTunes/GitTagData+Databases.swift
@@ -36,11 +36,20 @@ extension DatabaseContext {
   }
 }
 
+extension FlatDatabaseContext {
+  fileprivate func append(tag: String) -> FlatDatabaseContext {
+    guard let loggingToken else { return self }
+    return FlatDatabaseContext(storage: storage, loggingToken: "\(loggingToken)-\(tag)")
+  }
+}
+
 extension DatabaseFormat {
   fileprivate func append(tag: String) -> DatabaseFormat {
     switch self {
     case .normalized(let context):
       .normalized(context.append(tag: tag))
+    case .flat(let context):
+      .flat(context.append(tag: tag))
     }
   }
 }

--- a/Sources/iTunes/Track+RowPlay.swift
+++ b/Sources/iTunes/Track+RowPlay.swift
@@ -27,7 +27,7 @@ extension Track: RowPlayInterface {
     return (datePlayed, playCount)
   }
 
-  private var datePlayedISO8601: String {
+  var datePlayedISO8601: String {
     guard let playDateUTC else { return "" }
     return playDateUTC.formatted(.iso8601)
   }


### PR DESCRIPTION
- This is a flat database of the tracks that are "SQL encodable". This means they are music tracks (not videos, TV shows, etc).
- This database format will make data mining for corrections simpler.

Using the QueryCommand, something like the following will be useful to see all the changes over time to a track, artist, or album:

"ATTACH DATABASE '/tmp/all.db' AS ch; INSERT OR IGNORE INTO ch.tracks (tag, itunesid, name, sortname, artist, sortartist, album, sortalbum, tracknumber, trackcount, disccount, discnumber, year, duration, dateadded, compilation, composer, datereleased, comments, playdate, delta) SELECT ? AS tag, * FROM tracks WHERE album='Beyond';"