### PR TITLE
Add IdentifierCorrection and Add Patch/Repair.replaceDurations

### DIFF
--- a/Sources/iTunes/IdentifierCorrection.swift
+++ b/Sources/iTunes/IdentifierCorrection.swift
@@ -1,0 +1,41 @@
+//
+//  IdentifierCorrection.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 2/2/25.
+//
+
+import Foundation
+
+struct IdentifierCorrection: Codable, Comparable, Hashable, Sendable {
+  enum Property: Codable, Comparable, Hashable, Sendable {
+    case duration(Int?)
+
+    static func < (lhs: IdentifierCorrection.Property, rhs: IdentifierCorrection.Property) -> Bool {
+      switch (lhs, rhs) {
+      case (.duration(let lhv), .duration(let rhv)):
+        return lhv < rhv
+      }
+    }
+  }
+
+  let persistentID: UInt
+  let correction: Property
+
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    if lhs.persistentID == rhs.persistentID {
+      return lhs.correction < rhs.correction
+    }
+    return lhs.persistentID < rhs.persistentID
+  }
+}
+
+extension IdentifierCorrection: CustomStringConvertible {
+  var description: String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    guard let data = try? encoder.encode(self) else { return "" }
+    return (try? data.asUTF8String()) ?? ""
+  }
+}

--- a/Sources/iTunes/Patch.swift
+++ b/Sources/iTunes/Patch.swift
@@ -19,6 +19,7 @@ enum Patch: Sendable {
   case trackNumbers([SongTrackNumber])
   case years([SongYear])
   case songs([SongTitleCorrection])
+  case identifierCorrections([IdentifierCorrection])
 }
 
 // This will make a Dictionary<Key, Value> into Array<Key> where each Array
@@ -53,6 +54,8 @@ extension Patch: CustomStringConvertible {
     case .years(let items):
       return (try? (try? items.jsonData())?.asUTF8String()) ?? ""
     case .songs(let items):
+      return (try? (try? items.jsonData())?.asUTF8String()) ?? ""
+    case .identifierCorrections(let items):
       return (try? (try? items.jsonData())?.asUTF8String()) ?? ""
     }
   }

--- a/Sources/iTunes/Patch/Repairable.swift
+++ b/Sources/iTunes/Patch/Repairable.swift
@@ -18,4 +18,5 @@ enum Repairable: CaseIterable {
   case replaceTrackCounts
   case replaceDiscCounts
   case replaceDiscNumbers
+  case replaceDurations
 }

--- a/Sources/iTunes/Repair/Patchable.swift
+++ b/Sources/iTunes/Repair/Patchable.swift
@@ -19,4 +19,5 @@ enum Patchable: String, CaseIterable {
   case replaceTrackCounts
   case replaceDiscCounts
   case replaceDiscNumbers
+  case replaceDurations
 }

--- a/Sources/iTunes/Repair/RepairCommand.swift
+++ b/Sources/iTunes/Repair/RepairCommand.swift
@@ -46,6 +46,8 @@ extension Patchable {
       Patch.years(try Array<SongYear>.load(from: fileURL))
     case .songs:
       Patch.songs(try Array<SongTitleCorrection>.load(from: fileURL))
+    case .replaceDurations:
+      Patch.identifierCorrections(try Array<IdentifierCorrection>.load(from: fileURL))
     }
   }
 }

--- a/Sources/iTunes/Track+IdentifierCorrection.swift
+++ b/Sources/iTunes/Track+IdentifierCorrection.swift
@@ -1,0 +1,14 @@
+//
+//  Track+IdentifierCorrection.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 2/2/25.
+//
+
+import Foundation
+
+extension Track {
+  func identifierCorrection(_ correction: IdentifierCorrection.Property) -> IdentifierCorrection {
+    IdentifierCorrection(persistentID: persistentID, correction: correction)
+  }
+}


### PR DESCRIPTION
This is a much faster way; the batch query across the flat tracks database has demonstrated that with very few exceptions, the persistentID / itunesID remains consistent over the decades. This would be a better way to do the old repairs, but this is what will be used going forward. It may not be beneficial to change all that code now.