### PR TITLE
Add IdentifierCorrection.Property.persistentID

### DIFF
--- a/Sources/iTunes/IdentifierCorrection.swift
+++ b/Sources/iTunes/IdentifierCorrection.swift
@@ -10,11 +10,16 @@ import Foundation
 struct IdentifierCorrection: Codable, Comparable, Hashable, Sendable {
   enum Property: Codable, Comparable, Hashable, Sendable {
     case duration(Int?)
+    case persistentID(UInt)
 
     static func < (lhs: IdentifierCorrection.Property, rhs: IdentifierCorrection.Property) -> Bool {
       switch (lhs, rhs) {
       case (.duration(let lhv), .duration(let rhv)):
         return lhv < rhv
+      case (.persistentID(let lhv), .persistentID(let rhv)):
+        return lhv < rhv
+      default:
+        return false
       }
     }
   }

--- a/Sources/iTunes/Patch/Repairable.swift
+++ b/Sources/iTunes/Patch/Repairable.swift
@@ -19,4 +19,5 @@ enum Repairable: CaseIterable {
   case replaceDiscCounts
   case replaceDiscNumbers
   case replaceDurations
+  case replacePersistentIDs
 }

--- a/Sources/iTunes/Repair/Patchable.swift
+++ b/Sources/iTunes/Repair/Patchable.swift
@@ -20,4 +20,5 @@ enum Patchable: String, CaseIterable {
   case replaceDiscCounts
   case replaceDiscNumbers
   case replaceDurations
+  case replacePersistentIDs
 }

--- a/Sources/iTunes/Repair/RepairCommand.swift
+++ b/Sources/iTunes/Repair/RepairCommand.swift
@@ -46,7 +46,7 @@ extension Patchable {
       Patch.years(try Array<SongYear>.load(from: fileURL))
     case .songs:
       Patch.songs(try Array<SongTitleCorrection>.load(from: fileURL))
-    case .replaceDurations:
+    case .replaceDurations, .replacePersistentIDs:
       Patch.identifierCorrections(try Array<IdentifierCorrection>.load(from: fileURL))
     }
   }

--- a/Sources/iTunes/Track+Patch.swift
+++ b/Sources/iTunes/Track+Patch.swift
@@ -481,6 +481,72 @@ extension Track {
       isrc: isrc)
   }
 
+  fileprivate func apply(persistentID newPersistentID: UInt, tag: String) -> Track {
+    Logger.patch.info("Patching PersistentID: \(newPersistentID) - \(tag)")
+
+    return Track(
+      album: album,
+      albumArtist: albumArtist,
+      albumRating: albumRating,
+      albumRatingComputed: albumRatingComputed,
+      artist: artist,
+      bitRate: bitRate,
+      bPM: bPM,
+      comments: comments,
+      compilation: compilation,
+      composer: composer,
+      contentRating: contentRating,
+      dateAdded: dateAdded,
+      dateModified: dateModified,
+      disabled: disabled,
+      discCount: discCount,
+      discNumber: discNumber,
+      episode: episode,
+      episodeOrder: episodeOrder,
+      explicit: explicit,
+      genre: genre,
+      grouping: grouping,
+      hasVideo: hasVideo,
+      hD: hD,
+      kind: kind,
+      location: location,
+      movie: movie,
+      musicVideo: musicVideo,
+      name: name,
+      partOfGaplessAlbum: partOfGaplessAlbum,
+      persistentID: newPersistentID,
+      playCount: playCount,
+      playDateUTC: playDateUTC,
+      podcast: podcast,
+      protected: protected,
+      purchased: purchased,
+      rating: rating,
+      ratingComputed: ratingComputed,
+      releaseDate: releaseDate,
+      sampleRate: sampleRate,
+      season: season,
+      series: series,
+      size: size,
+      skipCount: skipCount,
+      skipDate: skipDate,
+      sortAlbum: sortAlbum,
+      sortAlbumArtist: sortAlbumArtist,
+      sortArtist: sortArtist,
+      sortComposer: sortComposer,
+      sortName: sortName,
+      sortSeries: sortSeries,
+      totalTime: totalTime,
+      trackCount: trackCount,
+      trackNumber: trackNumber,
+      trackType: trackType,
+      tVShow: tVShow,
+      unplayed: unplayed,
+      videoHeight: videoHeight,
+      videoWidth: videoWidth,
+      year: year,
+      isrc: isrc)
+  }
+
   fileprivate func apply(trackCorrection: TrackCorrection, tag: String) -> Track {
     Logger.patch.info("Patching TrackCorrection: \(trackCorrection) - \(tag)")
     switch trackCorrection.correction {
@@ -707,6 +773,9 @@ extension Track {
       guard let newValue else { return self }
       if let totalTime, totalTime == newValue { return self }
       return self.apply(duration: newValue, tag: tag)
+    case .persistentID(let newValue):
+      if persistentID == newValue { return self }
+      return self.apply(persistentID: newValue, tag: tag)
     }
   }
 }


### PR DESCRIPTION
- Just reads `--corrections "{<oldid>:<newid>,47:48}"`
- Not tested, too much else to grok yet, but this ought to work. :)