### PR TITLE
IdentifierCorrection.Property.comments is now non-optional

### DIFF
--- a/Sources/iTunes/IdentifierCorrection.swift
+++ b/Sources/iTunes/IdentifierCorrection.swift
@@ -13,7 +13,7 @@ struct IdentifierCorrection: Codable, Comparable, Hashable, Sendable {
     case persistentID(UInt)
     case dateAdded(Date?)
     case composer(String?)
-    case comments(String?)
+    case comments(String)
     case dateReleased(Date?)
     case albumTitle(SortableName?)
     case songTitle(SortableName)

--- a/Sources/iTunes/Patch/Repairable+Gather.swift
+++ b/Sources/iTunes/Patch/Repairable+Gather.swift
@@ -365,7 +365,7 @@ extension Repairable {
 
     case .replaceComments:
       return try await identifierCorrections(configuration: configuration) { track in
-        track.identifierCorrection(.comments(track.comments))
+        track.identifierCorrection(.comments(track.comments ?? ""))
       } qualifies: { item, current in
         switch (item.correction, current.correction) {
         case (.comments(let itemValue), .comments(let currentValue)):

--- a/Sources/iTunes/Track+Patch.swift
+++ b/Sources/iTunes/Track+Patch.swift
@@ -690,7 +690,7 @@ extension Track {
       artist: artist,
       bitRate: bitRate,
       bPM: bPM,
-      comments: newComments,
+      comments: !newComments.isEmpty ? newComments : nil,
       compilation: compilation,
       composer: composer,
       contentRating: contentRating,
@@ -1049,7 +1049,6 @@ extension Track {
       if let composer, composer == newValue { return self }
       return self.apply(composer: newValue, tag: tag)
     case .comments(let newValue):
-      guard let newValue else { return self }
       if let comments, comments == newValue { return self }
       return self.apply(comments: newValue, tag: tag)
     case .dateReleased(let newValue):


### PR DESCRIPTION
- This makes it simpler to "clear out" a comments field.