### PR TITLE
replaceDataAdded uses "first" dateAdded in history.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,12 +17,14 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     .package(url: "https://github.com/bolsinga/GitLibrary", from: "1.1.2"),
     .package(url: "https://github.com/DimaRU/PackageBuildInfo", from: "1.0.4"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
   ],
   targets: [
     .target(
       name: "iTunes",
       dependencies: [
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "Collections", package: "swift-collections"),
         .product(name: "GitLibrary", package: "GitLibrary"),
       ],
       resources: [.process("Resources/Localizable.xcstrings")],


### PR DESCRIPTION
Looking at the data aggregated by the flat database, the dateAdded property seems to be correct the first time it is added. It is only after the TZ changes that it is entered incorrectly. Since this should be an immutable value, use the first value added as the truth.

The general change for this Patch is that history, and not the current library values, are the source of truth.