### PR TITLE
Add replacePlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This will create patch files for the repair tool to use. It makes the assumption
 - `replace-id-disc-count` - Replace a disc count, using persistent ID, no other criteria.
 - `replace-id-disc-number` - Replace a disc number, using persistent ID, no other criteria.
 - `replace-artist` - Replace an artist name, using persistent ID, no other criteria.
+- `replace-play` - Replace play date and count looking at historical data.
 
 ### repair
 This will repair a git repository with listening history, given a file created with the patch tool. It has all the same options as the patch tool, found above. It has one additional option, listed below.

--- a/Sources/iTunes/IdentifierCorrection.swift
+++ b/Sources/iTunes/IdentifierCorrection.swift
@@ -23,6 +23,7 @@ struct IdentifierCorrection: Codable, Comparable, Hashable, Sendable {
     case discCount(Int)
     case discNumber(Int)
     case artist(SortableName?)
+    case play(old: Play, new: Play)
 
     static func < (lhs: IdentifierCorrection.Property, rhs: IdentifierCorrection.Property) -> Bool {
       switch (lhs, rhs) {
@@ -54,6 +55,11 @@ struct IdentifierCorrection: Codable, Comparable, Hashable, Sendable {
         return lhv < rhv
       case (.artist(let lhv), .artist(let rhv)):
         return lhv < rhv
+      case (.play(let lho, let lhn), .play(let rho, let rhn)):
+        if lhn == rhn {
+          return lho < rho
+        }
+        return lhn < rhn
       default:
         return false
       }

--- a/Sources/iTunes/Patch/Repairable.swift
+++ b/Sources/iTunes/Patch/Repairable.swift
@@ -32,4 +32,5 @@ enum Repairable: CaseIterable {
   case replaceIdDiscCount
   case replaceIdDiscNumber
   case replaceArtist
+  case replacePlay
 }

--- a/Sources/iTunes/Patchable+URL.swift
+++ b/Sources/iTunes/Patchable+URL.swift
@@ -53,7 +53,7 @@ extension Patchable {
     case .replaceDurations, .replacePersistentIds, .replaceDateAddeds, .replaceComposers,
       .replaceComments, .replaceDateReleased, .replaceAlbumTitle, .replaceSongTitle, .replaceYear,
       .replaceTrackNumber, .replaceIdSongTitle, .replaceIdDiscCount, .replaceIdDiscNumber,
-      .replaceArtist:
+      .replaceArtist, .replacePlay:
       try Self.identifierCorrections(fileURL)
     }
   }

--- a/Sources/iTunes/Patchable.swift
+++ b/Sources/iTunes/Patchable.swift
@@ -33,4 +33,5 @@ enum Patchable: String, CaseIterable {
   case replaceIdDiscCount
   case replaceIdDiscNumber
   case replaceArtist
+  case replacePlay
 }

--- a/Sources/iTunes/Play.swift
+++ b/Sources/iTunes/Play.swift
@@ -1,0 +1,204 @@
+//
+//  Play.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 2/16/25.
+//
+
+import Foundation
+
+struct Play: Codable, Comparable, Hashable, Sendable {
+  let date: Date?
+  let count: Int?
+
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    if lhs.date == rhs.date {
+      return lhs.count < rhs.count
+    }
+    return lhs.date < rhs.date
+  }
+}
+
+extension Track {
+  var play: Play { Play(date: playDateUTC, count: playCount) }
+}
+
+private enum Check {
+  /// The Play is good to use.
+  case good
+
+  /// They are duplicates.
+  case duplicate
+
+  /// The Play has a duplicate Date (including may be a DST one hour change). The associated Date should be used. The Play count is validly ascending.
+  case duplicateDate(Date)
+
+  /// The Play has a Date earlier than its self (which is not DST shifted).
+  case recedingDate
+
+  /// The count is receding, but the Date is OK.
+  case recedingCount
+
+  /// The count is empty. The Date has changed, so the count should reflect at least the associated count value.
+  case emptyCount(Int)
+
+  /// The Play is invalid; cannot determine what may be fixed.
+  case invalid
+}
+
+private enum DateComparisonResult {
+  case orderedAscending
+  case orderedSame
+  case orderedExactlyOneHour
+  case orderedDescending
+}
+
+extension ComparisonResult {
+  fileprivate var dateComparisonResult: DateComparisonResult {
+    switch self {
+    case .orderedAscending:
+      return .orderedAscending
+    case .orderedSame:
+      return .orderedSame
+    case .orderedDescending:
+      return .orderedDescending
+    }
+  }
+}
+
+extension Date {
+  fileprivate func compareQuirk(_ other: Date) -> DateComparisonResult {
+    guard abs(self.distance(to: other)) != 60 * 60 else { return .orderedExactlyOneHour }
+
+    return self.compare(other).dateComparisonResult
+  }
+}
+
+private enum PlayComparisonResult {
+  case orderedAscending
+  case orderedSame
+  case orderedExactlyOneHour
+  case orderedDescending
+
+  case invalid
+}
+
+extension DateComparisonResult {
+  fileprivate var playComparisonResult: PlayComparisonResult {
+    switch self {
+    case .orderedAscending:
+      return .orderedAscending
+    case .orderedSame:
+      return .orderedSame
+    case .orderedExactlyOneHour:
+      return .orderedExactlyOneHour
+    case .orderedDescending:
+      return .orderedDescending
+    }
+  }
+}
+
+extension Play {
+  fileprivate var isValid: Bool {
+    date != nil && count != nil
+  }
+
+  private func compareDate(_ other: Play) -> PlayComparisonResult {
+    switch (self.date, other.date) {
+    case (.some(let sDate), .some(let oDate)):
+      return sDate.compareQuirk(oDate).playComparisonResult
+    default:
+      return .invalid
+    }
+  }
+
+  private func compareCount(_ other: Play) -> PlayComparisonResult {
+    switch (self.count, other.count) {
+    case (.some(let sCount), .some(let oCount)):
+      let difference = sCount - oCount
+      if difference == 0 { return .orderedSame }
+      return difference < 1 ? .orderedAscending : .orderedDescending
+    default:
+      return .invalid
+    }
+  }
+
+  private func compare(_ other: Play) -> (
+    overall: PlayComparisonResult, date: PlayComparisonResult, count: PlayComparisonResult
+  ) {
+    let dateCompare = compareDate(other)
+    let countCompare = compareCount(other)
+
+    if dateCompare == countCompare {
+      return (dateCompare, dateCompare, countCompare)
+    }
+
+    if dateCompare == .orderedExactlyOneHour && countCompare == .orderedSame {
+      return (.orderedExactlyOneHour, dateCompare, countCompare)
+    }
+
+    return (.invalid, dateCompare, countCompare)
+  }
+
+  private func check(_ other: Play) -> Check {
+    let (comparison, dateCompare, countCompare) = self.compare(other)
+
+    switch comparison {
+    case .orderedAscending:
+      return .good
+    case .orderedSame:
+      return .duplicate
+    case .orderedExactlyOneHour:
+      guard let date else { return .invalid }
+      return .duplicateDate(date)
+    case .orderedDescending:
+      return .invalid
+    case .invalid:
+      switch (dateCompare, countCompare) {
+      case (.orderedDescending, .orderedAscending):
+        return .recedingDate
+      case (.orderedAscending, .orderedDescending):
+        guard let count, let otherCount = other.count, otherCount == 0 else {
+          return .recedingCount
+        }
+        return .emptyCount(count + 1)
+      case (.orderedAscending, .invalid):
+        guard let count else { return .invalid }
+        return .emptyCount(count + 1)
+      default:
+        return .invalid
+      }
+    }
+  }
+
+  fileprivate func normalize(_ other: Play) -> Play? {
+    switch check(other) {
+    case .good:
+      return other
+    case .duplicate:
+      return self
+    case .duplicateDate(let date):
+      return Play(date: date, count: other.count)
+    case .recedingDate:
+      return nil
+    case .recedingCount:
+      return nil
+    case .emptyCount(let count):
+      return Play(date: other.date, count: count)
+    case .invalid:
+      return nil
+    }
+  }
+}
+
+extension Array where Element == Play {
+  func normalize() -> [Element] {
+    guard let first, first.isValid else { return [] }
+
+    return self[1...].reduce(into: [first]) { partialResult, item in
+      guard let mostRecent = partialResult.last else { return }
+      guard let next = mostRecent.normalize(item) else { return }
+      partialResult.append(next)
+    }
+  }
+}

--- a/Sources/iTunes/PlayIdentity.swift
+++ b/Sources/iTunes/PlayIdentity.swift
@@ -1,0 +1,18 @@
+//
+//  PlayIdentity.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 2/16/25.
+//
+
+import Foundation
+
+struct PlayIdentity: Hashable, Identifiable, Sendable {
+  var id: UInt { persistentID }
+  let persistentID: UInt
+  let play: Play
+}
+
+extension Track {
+  var playIdentity: PlayIdentity { PlayIdentity(persistentID: persistentID, play: play) }
+}

--- a/Sources/iTunes/Track+Patch.swift
+++ b/Sources/iTunes/Track+Patch.swift
@@ -964,6 +964,73 @@ extension Track {
       isrc: isrc)
   }
 
+  fileprivate func apply(playDate newPlayDate: Date, count newPlayCount: Int, tag: String) -> Track
+  {
+    Logger.patch.info("Patching Play: \(newPlayDate) (\(newPlayCount)) - \(tag)")
+
+    return Track(
+      album: album,
+      albumArtist: albumArtist,
+      albumRating: albumRating,
+      albumRatingComputed: albumRatingComputed,
+      artist: artist,
+      bitRate: bitRate,
+      bPM: bPM,
+      comments: comments,
+      compilation: compilation,
+      composer: composer,
+      contentRating: contentRating,
+      dateAdded: dateAdded,
+      dateModified: dateModified,
+      disabled: disabled,
+      discCount: discCount,
+      discNumber: discNumber,
+      episode: episode,
+      episodeOrder: episodeOrder,
+      explicit: explicit,
+      genre: genre,
+      grouping: grouping,
+      hasVideo: hasVideo,
+      hD: hD,
+      kind: kind,
+      location: location,
+      movie: movie,
+      musicVideo: musicVideo,
+      name: name,
+      partOfGaplessAlbum: partOfGaplessAlbum,
+      persistentID: persistentID,
+      playCount: newPlayCount,
+      playDateUTC: newPlayDate,
+      podcast: podcast,
+      protected: protected,
+      purchased: purchased,
+      rating: rating,
+      ratingComputed: ratingComputed,
+      releaseDate: releaseDate,
+      sampleRate: sampleRate,
+      season: season,
+      series: series,
+      size: size,
+      skipCount: skipCount,
+      skipDate: skipDate,
+      sortAlbum: sortAlbum,
+      sortAlbumArtist: sortAlbumArtist,
+      sortArtist: sortArtist,
+      sortComposer: sortComposer,
+      sortName: sortName,
+      sortSeries: sortSeries,
+      totalTime: totalTime,
+      trackCount: trackCount,
+      trackNumber: trackNumber,
+      trackType: trackType,
+      tVShow: tVShow,
+      unplayed: unplayed,
+      videoHeight: videoHeight,
+      videoWidth: videoWidth,
+      year: year,
+      isrc: isrc)
+  }
+
   fileprivate func apply(song newSong: SortableName, tag: String) -> Track {
     Logger.patch.info("Patching Song: \(newSong) - \(tag)")
 
@@ -1080,6 +1147,10 @@ extension Track {
       guard let newValue else { return self }
       if artistName == newValue { return self }
       return self.apply(patch: newValue, tag: tag)
+    case .play(let badPlay, let goodPlay):
+      guard badPlay == self.play else { return self }
+      guard let date = goodPlay.date, let count = goodPlay.count else { return self }
+      return self.apply(playDate: date, count: count, tag: tag)
     }
   }
 }

--- a/Sources/iTunes/Track+Patch.swift
+++ b/Sources/iTunes/Track+Patch.swift
@@ -1147,9 +1147,9 @@ extension Track {
       guard let newValue else { return self }
       if artistName == newValue { return self }
       return self.apply(patch: newValue, tag: tag)
-    case .play(let badPlay, let goodPlay):
-      guard badPlay == self.play else { return self }
-      guard let date = goodPlay.date, let count = goodPlay.count else { return self }
+    case .play(let old, let new):
+      guard old == self.play else { return self }
+      guard let date = new.date, let count = new.count else { return self }
       return self.apply(playDate: date, count: count, tag: tag)
     }
   }

--- a/Tests/iTunes/PlayTests.swift
+++ b/Tests/iTunes/PlayTests.swift
@@ -1,0 +1,104 @@
+//
+//  PlayTests.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 2/16/25.
+//
+
+import Foundation
+import Testing
+
+@testable import iTunes
+
+extension Play {
+  fileprivate func advanced(by interval: TimeInterval) -> Play {
+    Play(date: date?.advanced(by: interval), count: count)
+  }
+
+  fileprivate func incremented(by difference: Int) -> Play {
+    Play(date: date, count: (count ?? 0) + difference)
+  }
+}
+
+struct PlayTests {
+  var date: Date { try! Date.ISO8601FormatStyle().parse("2005-12-22T23:06:50Z") }
+  let count = 5
+
+  var valid: Play { Play(date: self.date, count: count) }
+  var invalid: Play { Play(date: nil, count: nil) }
+
+  @Test func singleValid() async throws {
+    #expect([valid].normalize() == [valid])
+  }
+
+  @Test func singleInvalid() async throws {
+    #expect([invalid].normalize() == [])
+  }
+
+  @Test func invalidInitial() async throws {
+    #expect([invalid, valid].normalize() == [])
+  }
+
+  @Test func invalidOther() async throws {
+    #expect([valid, invalid].normalize() == [valid])
+  }
+
+  @Test func valid() async throws {
+    let other = valid.advanced(by: 60).incremented(by: 1)
+    #expect([valid, other].normalize() == [valid, other])
+  }
+
+  @Test func reverse() async throws {
+    let other = valid.advanced(by: -60).incremented(by: -1)
+    #expect([valid, other].normalize() == [valid])
+  }
+
+  @Test func same() async throws {
+    #expect([valid, valid].normalize() == [valid, valid])
+  }
+
+  @Test func advanceOneHourExactly() async throws {
+    let other = valid.advanced(by: 60 * 60)
+    #expect([valid, other].normalize() == [valid, valid])
+  }
+
+  @Test func reverseOneHourExactly() async throws {
+    let other = valid.advanced(by: -60 * 60)
+    #expect([valid, other].normalize() == [valid, valid])
+  }
+
+  @Test func reverseDateOnly() async throws {
+    let other = valid.advanced(by: -60)
+    #expect([valid, other].normalize() == [valid])
+  }
+
+  @Test func reverseDateAdvanceCount() async throws {
+    let other = valid.advanced(by: -60).incremented(by: 1)
+    #expect([valid, other].normalize() == [valid])
+  }
+
+  @Test func advanceDateOnly() async throws {
+    let other = valid.advanced(by: 60)
+    #expect([valid, other].normalize() == [valid])
+  }
+
+  @Test func advanceDateReverseCount() async throws {
+    let other = valid.advanced(by: 60).incremented(by: -1)
+    #expect([valid, other].normalize() == [valid])
+  }
+
+  @Test func advanceDateCountZero() async throws {
+    let other = valid.advanced(by: 60).incremented(by: -(valid.count ?? 0))
+    #expect([valid, other].normalize() == [valid, valid.advanced(by: 60).incremented(by: 1)])
+  }
+
+  @Test func advanceDateCountNil() async throws {
+    let other = Play(date: date.advanced(by: 60), count: nil)
+    #expect([valid, other].normalize() == [valid, valid.advanced(by: 60).incremented(by: 1)])
+  }
+
+  @Test func sameDateCountZero() async throws {
+    let other = valid.incremented(by: -(valid.count ?? 0))
+    #expect([valid, other].normalize() == [valid])
+  }
+}


### PR DESCRIPTION
This will look at the historical data. It will see if playDates are moving forward. This seems to find many TZ off by an hour problems.

However it does not seem to be able to fix the "we have a playdate but not a play count" problem. That will be addressed in a follow up.