### PR TITLE
update criteria for timestamp quirk.

### DIFF
--- a/Tests/iTunes/PlayTests.swift
+++ b/Tests/iTunes/PlayTests.swift
@@ -101,4 +101,12 @@ struct PlayTests {
     let other = valid.incremented(by: -(valid.count ?? 0))
     #expect([valid, other].normalize() == [valid])
   }
+
+  @Test func multipleOneHourDrifts() async throws {
+    #expect(
+      [
+        valid, valid.advanced(by: -60 * 60), valid.advanced(by: -60 * 60),
+        valid.advanced(by: -2 * 60 * 60),
+      ].normalize() == [valid, valid, valid, valid])
+  }
 }


### PR DESCRIPTION
An unchanged timestamp may drift by more than one hour. So when looking for the quirk, see if it changes within any exact multiple of one hour.

This covers some of the quirks found when logging was added. Fader Rules by Superchunk had the following:

```
2022-01-17T20:23:29Z|12
2022-01-17T19:23:29Z|12
2022-01-17T19:23:29Z|12
2022-01-17T18:23:29Z|12
```