### PR TITLE
keep initial invalid Plays in the array

### DIFF
--- a/Sources/iTunes/Play.swift
+++ b/Sources/iTunes/Play.swift
@@ -192,10 +192,11 @@ extension Play {
 
 extension Array where Element == Play {
   func normalize() -> [Element] {
-    guard let first, first.isValid else { return [] }
-
-    return self[1...].reduce(into: [first]) { partialResult, item in
-      guard let mostRecent = partialResult.last else { return }
+    return self.reduce(into: [Element]()) { partialResult, item in
+      guard let mostRecent = partialResult.last, mostRecent.isValid else {
+        partialResult.append(item)
+        return
+      }
       guard let next = mostRecent.normalize(item) else { return }
       partialResult.append(next)
     }

--- a/Tests/iTunes/PlayTests.swift
+++ b/Tests/iTunes/PlayTests.swift
@@ -32,11 +32,11 @@ struct PlayTests {
   }
 
   @Test func singleInvalid() async throws {
-    #expect([invalid].normalize() == [])
+    #expect([invalid].normalize() == [invalid])
   }
 
   @Test func invalidInitial() async throws {
-    #expect([invalid, valid].normalize() == [])
+    #expect([invalid, valid].normalize() == [invalid, valid])
   }
 
   @Test func invalidOther() async throws {


### PR DESCRIPTION
This is for when a Track may not have been played and has initial invalid Plays.

See "An Ambulance, Mike Krol, Merge Records Fall Sampler 2018". After it was added, it wasn't played until a few months later:

```
iTunes-V40-2018-12-01||0
iTunes-V40-2019-02-01|2019-02-01T00:18:39Z|1
iTunes-V40-2019-04-01|2019-03-07T21:12:18Z|3
iTunes-V40-2019-07-01|2019-06-11T23:54:02Z|4
iTunes-V40-2020-12-06|2019-06-12T00:54:02Z|4
iTunes-V40-2021-03-28|2019-06-11T23:54:02Z|4
iTunes-V40-2024-03-11|2019-06-11T22:54:02Z|4
iTunes-V40-2025-01-01.01|2025-01-02T01:28:19Z|5
```