### PR TITLE
Expose reason to log why something is failing

### DIFF
--- a/Sources/iTunes/Collection+PlayIdentity.swift
+++ b/Sources/iTunes/Collection+PlayIdentity.swift
@@ -15,7 +15,10 @@ extension Logger {
 extension Dictionary where Key == UInt, Value == [PlayIdentity] {
   func relevantChanges() -> [IdentifierCorrection] {
     let oldPlays = self.mapValues { $0.map { $0.play } }
-    let newPlays = oldPlays.mapValues { $0.normalize() }
+    let normalized = oldPlays.mapValues { $0.normalize() }
+    let newPlays = normalized.mapValues { $0.0 }
+
+    let checks = normalized.mapValues { $0.1 }
 
     guard oldPlays.count == newPlays.count else { return [] }
 
@@ -34,7 +37,8 @@ extension Dictionary where Key == UInt, Value == [PlayIdentity] {
       }
       guard oldPlays.count == newPlays.count else {
         Logger.play.info(
-          "Cannot Normalize: \(persistentID) old: \(oldPlays.count) new: \(newPlays.count)")
+          "Cannot Normalize: \(persistentID) old: \(oldPlays.count) new: \(newPlays.count) check: \(checks[persistentID] ?? "n/a")"
+        )
         return
       }
 

--- a/Tests/iTunes/PlayTests.swift
+++ b/Tests/iTunes/PlayTests.swift
@@ -20,6 +20,12 @@ extension Play {
   }
 }
 
+extension Array where Element == Play {
+  fileprivate func normalize() -> [Element] {
+    normalize().0
+  }
+}
+
 struct PlayTests {
   var date: Date { try! Date.ISO8601FormatStyle().parse("2005-12-22T23:06:50Z") }
   let count = 5


### PR DESCRIPTION
Return Check as a String so that an association may be made between persistentIDs and their failure to normalize.