### PR TITLE
Use Patch file pathExtension to load corrections.

### DIFF
--- a/Sources/iTunes/BackupCommand.swift
+++ b/Sources/iTunes/BackupCommand.swift
@@ -165,7 +165,7 @@ struct BackupCommand: AsyncParsableCommand {
   func tracks() async throws -> [Track] {
     var tracks = try await source.gather(reduce: reduce)
     if let patchURL {
-      tracks = try tracks.backupPatch(patchURL)
+      tracks = try await tracks.backupPatch(patchURL)
     }
     return tracks
   }

--- a/Sources/iTunes/Patch+URL.swift
+++ b/Sources/iTunes/Patch+URL.swift
@@ -34,7 +34,7 @@ extension URL {
     }
   }
 
-  fileprivate func corrections(in url: URL) async throws -> [IdentifierCorrection] {
+  fileprivate func corrections() async throws -> [IdentifierCorrection] {
     enum CorrectionsError: Error {
       case unknownPatchFileType
     }
@@ -42,13 +42,13 @@ extension URL {
     case .unknown:
       throw CorrectionsError.unknownPatchFileType
     case .json:
-      return try Array<IdentifierCorrection>.load(from: url)
+      return try Array<IdentifierCorrection>.load(from: self)
     }
   }
 }
 
 extension Patch {
   static func load(_ url: URL) async throws -> Patch {
-    .identifierCorrections(try await url.corrections(in: url))
+    .identifierCorrections(try await url.corrections())
   }
 }

--- a/Sources/iTunes/Patch+URL.swift
+++ b/Sources/iTunes/Patch+URL.swift
@@ -19,9 +19,36 @@ extension Array where Element: Codable {
   }
 }
 
+private enum PatchType {
+  case unknown
+  case json
+}
+
+extension URL {
+  fileprivate var patchType: PatchType {
+    switch pathExtension {
+    case "json":
+      .json
+    default:
+      .unknown
+    }
+  }
+
+  fileprivate func corrections(in url: URL) async throws -> [IdentifierCorrection] {
+    enum CorrectionsError: Error {
+      case unknownPatchFileType
+    }
+    switch patchType {
+    case .unknown:
+      throw CorrectionsError.unknownPatchFileType
+    case .json:
+      return try Array<IdentifierCorrection>.load(from: url)
+    }
+  }
+}
+
 extension Patch {
-  static func load(_ url: URL) throws -> Patch {
-    let corrections = try Array<IdentifierCorrection>.load(from: url)
-    return .identifierCorrections(corrections)
+  static func load(_ url: URL) async throws -> Patch {
+    .identifierCorrections(try await url.corrections(in: url))
   }
 }

--- a/Sources/iTunes/Patchable+URL.swift
+++ b/Sources/iTunes/Patchable+URL.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 extension Patchable {
-  func createPatch(_ fileURL: URL) throws -> Patch {
+  func createPatch(_ fileURL: URL) async throws -> Patch {
     switch self {
     case .replaceDurations, .replacePersistentIds, .replaceDateAddeds, .replaceComposers,
       .replaceComments, .replaceDateReleased, .replaceAlbumTitle, .replaceYear,
       .replaceTrackNumber, .replaceIdSongTitle, .replaceIdDiscCount, .replaceIdDiscNumber,
       .replaceArtist, .replacePlay:
-      try Patch.load(fileURL)
+      try await Patch.load(fileURL)
     }
   }
 }

--- a/Sources/iTunes/Repair/RepairCommand.swift
+++ b/Sources/iTunes/Repair/RepairCommand.swift
@@ -41,7 +41,7 @@ struct RepairCommand: AsyncParsableCommand {
   var destinationBranch: String?
 
   func run() async throws {
-    let patch = try patchable.createPatch(patchURL)
+    let patch = try await patchable.createPatch(patchURL)
 
     let sourceConfiguration = GitTagData.Configuration(
       directory: gitDirectory, fileName: Self.fileName)

--- a/Sources/iTunes/Track+Patch.swift
+++ b/Sources/iTunes/Track+Patch.swift
@@ -1025,7 +1025,7 @@ extension Array where Element == Track {
     try patchTracks(patch, tag: tag).jsonData()
   }
 
-  func backupPatch(_ patchURL: URL) throws -> [Track] {
-    try patchTracks(try Patch.load(patchURL), tag: "")
+  func backupPatch(_ patchURL: URL) async throws -> [Track] {
+    try patchTracks(try await Patch.load(patchURL), tag: "")
   }
 }


### PR DESCRIPTION
- Right now only JSON is supported.
- Also declare Patch loading as async, since future uses will require it.