### PR TITLE
Add CorrectionsDB

### DIFF
--- a/Sources/iTunes/CorrectionsDBContext.swift
+++ b/Sources/iTunes/CorrectionsDBContext.swift
@@ -1,0 +1,108 @@
+//
+//  CorrectionsDBContext.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 2/23/25.
+//
+
+import Foundation
+
+struct CorrectionsDBContext: FlatDBEncoderContext {
+  let storage: DatabaseStorage
+
+  var context: Database.Context {
+    Database.Context(storage: storage, loggingToken: nil)
+  }
+
+  func insertStatement(_ item: IdentifierCorrection) -> Database.Statement {
+    CorrectionsDBRow.insertStatement(item)
+  }
+
+  func row(for item: IdentifierCorrection) -> CorrectionsDBRow {
+    CorrectionsDBRow(correction: item)
+  }
+
+  var schema: String = """
+    CREATE TABLE IF NOT EXISTS correct_id (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value TEXT,
+      CHECK(length(value) > 0)
+    );
+    CREATE TABLE IF NOT EXISTS correct_song (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      name TEXT,
+      sort TEXT,
+      CHECK(length(name) > 0)
+    );
+    CREATE TABLE IF NOT EXISTS correct_artist (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      name TEXT,
+      sort TEXT,
+      CHECK(length(name) > 0)
+    );
+    CREATE TABLE IF NOT EXISTS correct_album (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      name TEXT,
+      sort TEXT,
+      CHECK(length(name) > 0)
+    );
+    CREATE TABLE IF NOT EXISTS correct_tracknumber (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS correct_trackcount (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS correct_discnumber (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS correct_disccount (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS correct_year (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS correct_duration (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS correct_added (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      date TEXT,
+      CHECK(length(date) > 0)
+    );
+    CREATE TABLE IF NOT EXISTS correct_compilation (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value INTEGER,
+      CHECK(value = 0 OR value = 1)
+    );
+    CREATE TABLE IF NOT EXISTS correct_composer (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value TEXT,
+      CHECK(length(value) > 0)
+    );
+    CREATE TABLE IF NOT EXISTS correct_released (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      date TEXT,
+      CHECK(length(date) > 0)
+    );
+    CREATE TABLE IF NOT EXISTS correct_comment (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      value TEXT,
+      CHECK(length(value) > 0)
+    );
+    CREATE TABLE IF NOT EXISTS correct_play (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      olddate TEXT,
+      oldcount INTEGER,
+      newdate TEXT,
+      newcount INTEGER,
+      CHECK(length(olddate) > 0),
+      CHECK(length(newdate) > 0)
+    );
+    """
+}

--- a/Sources/iTunes/CorrectionsDBRow.swift
+++ b/Sources/iTunes/CorrectionsDBRow.swift
@@ -1,0 +1,204 @@
+//
+//  CorrectionsDBRow.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 2/23/25.
+//
+
+import Foundation
+
+extension IdentifierCorrection.Property {
+  fileprivate var newitunesid: String? {
+    if case .persistentID(let v) = self { String(v) } else { nil }
+  }
+  fileprivate var name: String? {
+    if case .replaceSongTitle(let v) = self { v.name } else { nil }
+  }
+  fileprivate var sortname: String? {
+    if case .replaceSongTitle(let v) = self { v.sorted } else { nil }
+  }
+  fileprivate var artist: String? {
+    if case .artist(let v) = self { v?.name } else { nil }
+  }
+  fileprivate var sortartist: String? {
+    if case .artist(let v) = self { v?.sorted } else { nil }
+  }
+  fileprivate var album: String? {
+    if case .albumTitle(let v) = self { v?.name } else { nil }
+  }
+  fileprivate var sortalbum: String? {
+    if case .albumTitle(let v) = self { v?.sorted } else { nil }
+  }
+  fileprivate var tracknumber: Int? {
+    if case .trackNumber(let v) = self { v } else { nil }
+  }
+  fileprivate var trackcount: Int? { nil }
+  fileprivate var disccount: Int? {
+    if case .discCount(let v) = self { v } else { nil }
+  }
+  fileprivate var discnumber: Int? {
+    if case .discNumber(let v) = self { v } else { nil }
+  }
+  fileprivate var year: Int? {
+    if case .trackNumber(let v) = self { v } else { nil }
+  }
+  fileprivate var duration: Int? {
+    if case .trackNumber(let v) = self { v } else { nil }
+  }
+  fileprivate var dateadded: String? {
+    if case .dateAdded(let v) = self { v?.formatted(.iso8601) } else { nil }
+  }
+  fileprivate var compilation: Int? { nil }
+  fileprivate var composer: String? {
+    if case .composer(let v) = self { v } else { nil }
+  }
+  fileprivate var datereleased: String? {
+    if case .dateReleased(let v) = self { v?.formatted(.iso8601) } else { nil }
+  }
+  fileprivate var comments: String? {
+    if case .comments(let v) = self { v } else { nil }
+  }
+  fileprivate var oldplaydate: String? {
+    if case .play(let v, _) = self { v.date?.formatted(.iso8601) } else { nil }
+  }
+  fileprivate var oldplaycount: Int? {
+    if case .play(let v, _) = self { v.count } else { nil }
+  }
+  fileprivate var newplaydate: String? {
+    if case .play(_, let v) = self { v.date?.formatted(.iso8601) } else { nil }
+  }
+  fileprivate var newplaycount: Int? {
+    if case .play(_, let v) = self { v.count } else { nil }
+  }
+}
+
+struct CorrectionsDBRow: FlatRow {
+  let correction: IdentifierCorrection
+
+  fileprivate var itunesid: String { String(correction.persistentID) }
+  fileprivate var newitunesid: String? { correction.correction.newitunesid }
+  fileprivate var name: String? { correction.correction.name }
+  fileprivate var sortname: String? { correction.correction.sortname }
+  fileprivate var artist: String? { correction.correction.artist }
+  fileprivate var sortartist: String? { correction.correction.sortartist }
+  fileprivate var album: String? { correction.correction.album }
+  fileprivate var sortalbum: String? { correction.correction.sortalbum }
+  fileprivate var tracknumber: Int? { correction.correction.tracknumber }
+  fileprivate var trackcount: Int? { correction.correction.trackcount }
+  fileprivate var disccount: Int? { correction.correction.disccount }
+  fileprivate var discnumber: Int? { correction.correction.discnumber }
+  fileprivate var year: Int? { correction.correction.year }
+  fileprivate var duration: Int? { correction.correction.duration }
+  fileprivate var dateadded: String? { correction.correction.dateadded }
+  fileprivate var compilation: Int? { correction.correction.compilation }
+  fileprivate var composer: String? { correction.correction.composer }
+  fileprivate var datereleased: String? { correction.correction.datereleased }
+  fileprivate var comments: String? { correction.correction.comments }
+  fileprivate var oldplaydate: String? { correction.correction.oldplaydate }
+  fileprivate var oldplaycount: Int? { correction.correction.oldplaycount }
+  fileprivate var newplaydate: String? { correction.correction.newplaydate }
+  fileprivate var newplaycount: Int? { correction.correction.newplaycount }
+
+  var parameters: [Database.Value] { insert.parameters }
+
+  private var correctID: Database.Statement {
+    "INSERT OR IGNORE INTO correct_id (itunesid, value) VALUES (\(itunesid), \(newitunesid));"
+  }
+
+  private var correctSong: Database.Statement {
+    "INSERT OR IGNORE INTO correct_song (itunesid, name, sort) VALUES (\(itunesid), \(name), \(sortname));"
+  }
+
+  private var correctArtist: Database.Statement {
+    "INSERT OR IGNORE INTO correct_artist (itunesid, name, sort) VALUES (\(itunesid), \(artist), \(sortartist));"
+  }
+
+  private var correctAlbum: Database.Statement {
+    "INSERT OR IGNORE INTO correct_album (itunesid, name, sort) VALUES (\(itunesid), \(album), \(sortalbum));"
+  }
+
+  private var correctTrackNumber: Database.Statement {
+    "INSERT OR IGNORE INTO correct_tracknumber (itunesid, value) VALUES (\(itunesid), \(tracknumber));"
+  }
+
+  private var correctTrackCount: Database.Statement {
+    "INSERT OR IGNORE INTO correct_trackcount (itunesid, value) VALUES (\(itunesid), \(trackcount));"
+  }
+
+  private var correctDiscNumber: Database.Statement {
+    "INSERT OR IGNORE INTO correct_discnumber (itunesid, value) VALUES (\(itunesid), \(discnumber));"
+  }
+
+  private var correctDiscCount: Database.Statement {
+    "INSERT OR IGNORE INTO correct_disccount (itunesid, value) VALUES (\(itunesid), \(disccount));"
+  }
+
+  private var correctYear: Database.Statement {
+    "INSERT OR IGNORE INTO correct_year (itunesid, value) VALUES (\(itunesid), \(year));"
+  }
+
+  private var correctDuration: Database.Statement {
+    "INSERT OR IGNORE INTO correct_duration (itunesid, value) VALUES (\(itunesid), \(duration));"
+  }
+
+  private var correctAdded: Database.Statement {
+    "INSERT OR IGNORE INTO correct_added (itunesid, date) VALUES (\(itunesid), \(dateadded));"
+  }
+
+  private var correctCompilation: Database.Statement {
+    "INSERT OR IGNORE INTO correct_compilation (itunesid, value) VALUES (\(itunesid), \(compilation));"
+  }
+
+  private var correctComposer: Database.Statement {
+    "INSERT OR IGNORE INTO correct_composer (itunesid, value) VALUES (\(itunesid), \(composer));"
+  }
+
+  private var correctReleased: Database.Statement {
+    "INSERT OR IGNORE INTO correct_released (itunesid, date) VALUES (\(itunesid), \(datereleased));"
+  }
+
+  private var correctComment: Database.Statement {
+    "INSERT OR IGNORE INTO correct_comment (itunesid, value) VALUES (\(itunesid), \(comments));"
+  }
+
+  private var correctPlay: Database.Statement {
+    "INSERT OR IGNORE INTO correct_play (itunesid, olddate, oldcount, newdate, newcount) VALUES (\(itunesid), \(oldplaydate), \(oldplaycount), \(newplaydate), \(newplaycount));"
+  }
+
+  private var insert: Database.Statement {
+    switch correction.correction {
+    case .duration(_):
+      correctDuration
+    case .persistentID(_):
+      correctID
+    case .dateAdded(_):
+      correctAdded
+    case .composer(_):
+      correctComposer
+    case .comments(_):
+      correctComment
+    case .dateReleased(_):
+      correctReleased
+    case .albumTitle(_):
+      correctAlbum
+    case .year(_):
+      correctYear
+    case .trackNumber(_):
+      correctTrackNumber
+    case .replaceSongTitle(_):
+      correctSong
+    case .discCount(_):
+      correctDiscCount
+    case .discNumber(_):
+      correctDiscNumber
+    case .artist(_):
+      correctArtist
+    case .play(_, _):
+      correctPlay
+    }
+  }
+
+  static func insertStatement(_ item: IdentifierCorrection) -> Database.Statement {
+    CorrectionsDBRow(correction: item).insert
+  }
+}

--- a/Sources/iTunes/IdentifierCorrection+Database.swift
+++ b/Sources/iTunes/IdentifierCorrection+Database.swift
@@ -1,0 +1,55 @@
+//
+//  IdentifierCorrection+Database.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 2/25/25.
+//
+
+import Foundation
+
+private var duration: String { "SELECT * FROM 'correct_duration';" }
+private var persistentID: String { "SELECT * FROM 'correct_id';" }
+private var dateAdded: String { "SELECT * FROM 'correct_added';" }
+private var composer: String { "SELECT * FROM 'correct_composer';" }
+private var comments: String { "SELECT * FROM 'correct_comment';" }
+private var dateReleased: String { "SELECT * FROM 'correct_released';" }
+private var albumTitle: String { "SELECT * FROM 'correct_album';" }
+private var year: String { "SELECT * FROM 'correct_year';" }
+private var trackNumber: String { "SELECT * FROM 'correct_tracknumber';" }
+private var replaceSongTitle: String { "SELECT * FROM 'correct_song';" }
+private var discCount: String { "SELECT * FROM 'correct_disccount';" }
+private var discNumber: String { "SELECT * FROM 'correct_discnumber';" }
+private var artist: String { "SELECT * FROM 'correct_artist';" }
+private var play: String { "SELECT * FROM 'correct_play';" }
+
+private var statementConverters: [(String, (Database.Row) -> IdentifierCorrection?)] {
+  [
+    (duration, IdentifierCorrection.duration(row:)),
+    (persistentID, IdentifierCorrection.persistentID(row:)),
+    (dateAdded, IdentifierCorrection.dateAdded(row:)),
+    (composer, IdentifierCorrection.composer(row:)),
+    (comments, IdentifierCorrection.comments(row:)),
+    (dateReleased, IdentifierCorrection.dateReleased(row:)),
+    (albumTitle, IdentifierCorrection.albumTitle(row:)),
+    (year, IdentifierCorrection.year(row:)),
+    (trackNumber, IdentifierCorrection.trackNumber(row:)),
+    (replaceSongTitle, IdentifierCorrection.replaceSongTitle(row:)),
+    (discCount, IdentifierCorrection.discCount(row:)),
+    (discNumber, IdentifierCorrection.discNumber(row:)),
+    (artist, IdentifierCorrection.artist(row:)),
+    (play, IdentifierCorrection.play(row:)),
+  ]
+}
+
+extension Database {
+  func identifierCorrections() throws -> [IdentifierCorrection] {
+    let corrections = try statementConverters.flatMap { pair in
+      let (statement, converter) = pair
+      return try execute(query: statement, arguments: []).flatMap {
+        $0.compactMap { converter($0) }
+      }
+    }
+    close()
+    return corrections
+  }
+}

--- a/Sources/iTunes/IdentifierCorrection+Database.swift
+++ b/Sources/iTunes/IdentifierCorrection+Database.swift
@@ -7,22 +7,22 @@
 
 import Foundation
 
-private var duration: String { "SELECT * FROM 'correct_duration';" }
-private var persistentID: String { "SELECT * FROM 'correct_id';" }
-private var dateAdded: String { "SELECT * FROM 'correct_added';" }
-private var composer: String { "SELECT * FROM 'correct_composer';" }
-private var comments: String { "SELECT * FROM 'correct_comment';" }
-private var dateReleased: String { "SELECT * FROM 'correct_released';" }
-private var albumTitle: String { "SELECT * FROM 'correct_album';" }
-private var year: String { "SELECT * FROM 'correct_year';" }
-private var trackNumber: String { "SELECT * FROM 'correct_tracknumber';" }
-private var replaceSongTitle: String { "SELECT * FROM 'correct_song';" }
-private var discCount: String { "SELECT * FROM 'correct_disccount';" }
-private var discNumber: String { "SELECT * FROM 'correct_discnumber';" }
-private var artist: String { "SELECT * FROM 'correct_artist';" }
-private var play: String { "SELECT * FROM 'correct_play';" }
+private let duration = "SELECT * FROM 'correct_duration';"
+private let persistentID = "SELECT * FROM 'correct_id';"
+private let dateAdded = "SELECT * FROM 'correct_added';"
+private let composer = "SELECT * FROM 'correct_composer';"
+private let comments = "SELECT * FROM 'correct_comment';"
+private let dateReleased = "SELECT * FROM 'correct_released';"
+private let albumTitle = "SELECT * FROM 'correct_album';"
+private let year = "SELECT * FROM 'correct_year';"
+private let trackNumber = "SELECT * FROM 'correct_tracknumber';"
+private let replaceSongTitle = "SELECT * FROM 'correct_song';"
+private let discCount = "SELECT * FROM 'correct_disccount';"
+private let discNumber = "SELECT * FROM 'correct_discnumber';"
+private let artist = "SELECT * FROM 'correct_artist';"
+private let play = "SELECT * FROM 'correct_play';"
 
-private var statementConverters: [(String, (Database.Row) -> IdentifierCorrection?)] {
+private let statementConverters =
   [
     (duration, IdentifierCorrection.duration(row:)),
     (persistentID, IdentifierCorrection.persistentID(row:)),
@@ -39,7 +39,6 @@ private var statementConverters: [(String, (Database.Row) -> IdentifierCorrectio
     (artist, IdentifierCorrection.artist(row:)),
     (play, IdentifierCorrection.play(row:)),
   ]
-}
 
 extension Database {
   func identifierCorrections() throws -> [IdentifierCorrection] {

--- a/Sources/iTunes/IdentifierCorrection+Row.swift
+++ b/Sources/iTunes/IdentifierCorrection+Row.swift
@@ -1,0 +1,159 @@
+//
+//  IdentifierCorrection+Row.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 2/25/25.
+//
+
+import Foundation
+
+extension DatabaseRowLookup {
+  fileprivate var itunesid: UInt? { if let v = string("itunesid") { UInt(v) } else { nil } }
+
+  fileprivate var name: String? { string("name") }
+  fileprivate var sort: String? { string("sort") }
+
+  fileprivate var sortableName: SortableName? {
+    guard let name else { return nil }
+    return SortableName(name: name, sorted: sort ?? "")
+  }
+
+  fileprivate var integerValue: Int? { integer("value") }
+  fileprivate var stringValue: String? { string("value") }
+
+  fileprivate var date: Date? { date("date") }
+
+  fileprivate var oldPlay: Play { Play(date: date("olddate"), count: integer("oldcount")) }
+  fileprivate var newPlay: Play { Play(date: date("newdate"), count: integer("newcount")) }
+
+  fileprivate var duration: IdentifierCorrection.Property? {
+    .duration(integerValue)
+  }
+
+  fileprivate var persistentID: IdentifierCorrection.Property? {
+    guard let value = stringValue, let id = UInt(value) else { return nil }
+    return .persistentID(id)
+  }
+
+  fileprivate var dateAdded: IdentifierCorrection.Property? {
+    .dateAdded(date)
+  }
+
+  fileprivate var composer: IdentifierCorrection.Property? {
+    guard let value = stringValue else { return nil }
+    return .composer(value)
+  }
+
+  fileprivate var comments: IdentifierCorrection.Property? {
+    guard let value = stringValue else { return nil }
+    return .comments(value)
+  }
+
+  fileprivate var dateReleased: IdentifierCorrection.Property? {
+    .dateReleased(date)
+  }
+
+  fileprivate var albumTitle: IdentifierCorrection.Property? {
+    .albumTitle(sortableName)
+  }
+
+  fileprivate var year: IdentifierCorrection.Property? {
+    guard let value = integerValue else { return nil }
+    return .year(value)
+  }
+
+  fileprivate var trackNumber: IdentifierCorrection.Property? {
+    guard let value = integerValue else { return nil }
+    return .trackNumber(value)
+  }
+
+  fileprivate var replaceSongTitle: IdentifierCorrection.Property? {
+    guard let sortableName else { return nil }
+    return .replaceSongTitle(sortableName)
+  }
+
+  fileprivate var discCount: IdentifierCorrection.Property? {
+    guard let value = integerValue else { return nil }
+    return .discCount(value)
+  }
+
+  fileprivate var discNumber: IdentifierCorrection.Property? {
+    guard let value = integerValue else { return nil }
+    return .discNumber(value)
+  }
+
+  fileprivate var artist: IdentifierCorrection.Property? {
+    .artist(sortableName)
+  }
+
+  fileprivate var play: IdentifierCorrection.Property? {
+    .play(old: oldPlay, new: newPlay)
+  }
+}
+
+extension IdentifierCorrection {
+  init?(row: Database.Row, property: (DatabaseRowLookup) -> Property?) {
+    let lookup = DatabaseRowLookup(row: row)
+
+    guard let itunesid = lookup.itunesid else { return nil }
+    guard let property = property(lookup) else { return nil }
+
+    self.init(persistentID: itunesid, correction: property)
+  }
+
+  static func duration(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.duration }
+  }
+
+  static func persistentID(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.persistentID }
+  }
+
+  static func dateAdded(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.dateAdded }
+  }
+
+  static func composer(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.composer }
+  }
+
+  static func comments(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.comments }
+  }
+
+  static func dateReleased(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.dateReleased }
+  }
+
+  static func albumTitle(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.albumTitle }
+  }
+
+  static func year(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.year }
+  }
+
+  static func trackNumber(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.trackNumber }
+  }
+
+  static func replaceSongTitle(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.replaceSongTitle }
+  }
+
+  static func discCount(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.discCount }
+  }
+
+  static func discNumber(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.discNumber }
+  }
+
+  static func artist(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.artist }
+  }
+
+  static func play(row: Database.Row) -> IdentifierCorrection? {
+    self.init(row: row) { $0.play }
+  }
+}

--- a/Sources/iTunes/Patch+URL.swift
+++ b/Sources/iTunes/Patch+URL.swift
@@ -22,6 +22,7 @@ extension Array where Element: Codable {
 private enum PatchType {
   case unknown
   case json
+  case database
 }
 
 extension URL {
@@ -29,9 +30,15 @@ extension URL {
     switch pathExtension {
     case "json":
       .json
+    case "db":
+      .database
     default:
       .unknown
     }
+  }
+
+  fileprivate func database() throws -> Database {
+    try Database(context: Database.Context(storage: .file(self), loggingToken: nil))
   }
 
   fileprivate func corrections() async throws -> [IdentifierCorrection] {
@@ -43,6 +50,8 @@ extension URL {
       throw CorrectionsError.unknownPatchFileType
     case .json:
       return try Array<IdentifierCorrection>.load(from: self)
+    case .database:
+      return try await database().identifierCorrections()
     }
   }
 }


### PR DESCRIPTION
This database contains patches.
- It can be written to by the patch option
- It can be used by the backup option.
- It can be used by the repair option.

This database can be read by nightly backups and applied. This is necessary since the Library may provide incorrect data, compared to the historical truth that is currently backed up. It's useful to have in this database, because with so many dates changing over history, they all have to be corrected. The json files are too large, and the database of corrections is smaller. It's also good going forward.

Fixes #727