### PR TITLE
BackupCommand always reads the latest tags from git

### DIFF
--- a/Sources/iTunes/BackupCommand.swift
+++ b/Sources/iTunes/BackupCommand.swift
@@ -129,10 +129,6 @@ struct BackupCommand: AsyncParsableCommand {
   )
   var fileName: String?
 
-  @Option(
-    help: "The prefix to use for the git tags. If not set, will try to find most recent tag prefix."
-  ) var tagPrefix: String?
-
   /// Patch File URL.
   @Option(
     help: "Patch JSON file path.",
@@ -148,7 +144,7 @@ struct BackupCommand: AsyncParsableCommand {
   }
 
   private var context: BackupContext {
-    BackupContext(tagPrefix: tagPrefix, version: Self.configuration.version)
+    BackupContext(version: Self.configuration.version)
   }
 
   /// Validates the input matrix.

--- a/Sources/iTunes/BackupContext.swift
+++ b/Sources/iTunes/BackupContext.swift
@@ -11,11 +11,9 @@ import GitLibrary
 struct BackupContext: Sendable {
   static let defaultTag = "iTunes"
 
-  let tagPrefix: String?
   let version: String
 
   func tag(_ git: Git) async throws -> String {
-    if let tagPrefix { return tagPrefix }
     guard let currentPrefix = try await git.describeTag()?.tagPrefix else {
       return Self.defaultTag
     }


### PR DESCRIPTION
This technically "breaks" the very first commit in git. However if anyone else should use this in the future, they won't have a git repository; they will back up originally to a sqllite db.