### PR TITLE
these do not need to be inlinable

### DIFF
--- a/Sources/iTunes/Batch/Batch.swift
+++ b/Sources/iTunes/Batch/Batch.swift
@@ -31,8 +31,7 @@ extension Tag where Item == Data {
 }
 
 extension Batch {
-  @inlinable
-  func destination(tag: String, schemaOptions: SchemaOptions) -> Destination {
+  fileprivate func destination(tag: String, schemaOptions: SchemaOptions) -> Destination {
     switch self {
     case .sql:
       Destination.sqlCode(
@@ -49,8 +48,7 @@ extension Batch {
     }
   }
 
-  @inlinable
-  var pathExtension: String {
+  fileprivate var pathExtension: String {
     switch self {
     case .sql:
       "sql"


### PR DESCRIPTION
- This isn't going to be "used" outside the module, so this is unecessary. See https://forums.swift.org/t/when-should-both-inlinable-and-inline-always-be-used/37375
- additionally make them fileprivate