### PR TITLE
writing out patched [Tag<Data>] no longer uses GitTagData

### DIFF
--- a/Sources/iTunes/GitTagData.swift
+++ b/Sources/iTunes/GitTagData.swift
@@ -13,38 +13,6 @@ extension Logger {
   fileprivate static let gitTagData = Logger(category: "gitTagData")
 }
 
-extension Git {
-  fileprivate func addAndTag(fileName: String, tag tagName: String, version: String) async throws {
-    try await add(fileName)
-
-    let hasChanges = await {
-      do {
-        try await diff()
-        Logger.gitTagData.info("Empty Tag: \(tagName)")
-        return false
-      } catch {
-        return true
-      }
-    }()
-
-    if hasChanges {
-      try await commit("\(tagName)\n\(version)")
-    }
-    try await tag(tagName)
-  }
-}
-
-extension Tag where Item == Data {
-  fileprivate func add(to git: Git, backupFile: URL, version: String) async throws {
-    Logger.gitTagData.info("Add: \(tag)")
-
-    // this makes memory shoot up, unexpectedly.
-    try item.write(to: backupFile)
-
-    try await git.addAndTag(fileName: backupFile.lastPathComponent, tag: tag, version: version)
-  }
-}
-
 struct GitTagData {
   let backupFile: URL
   private let git: Git
@@ -113,25 +81,5 @@ struct GitTagData {
 
     }
     return tagDatum
-  }
-
-  func write(tagDatum: [Tag<Data>], initialCommit: String, branch: String, version: String)
-    async throws
-  {
-    try await git.status()
-
-    try await git.createBranch(named: branch, initialCommit: initialCommit)
-
-    var tagDatum = tagDatum.sorted(by: { $0.tag > $1.tag })  // latest to oldest.
-
-    for tagData in tagDatum.reversed() {
-      tagDatum.removeLast()
-
-      try await tagData.add(to: git, backupFile: backupFile, version: version)
-    }
-
-    //    try await git.push()
-    //    try await git.pushTags()
-    //    try await git.gc()
   }
 }

--- a/Sources/iTunes/Repair/Patch+Build.swift
+++ b/Sources/iTunes/Repair/Patch+Build.swift
@@ -25,8 +25,8 @@ extension Patch {
 
     guard let initialCommit = patchedTracksData.initialTag else { return }
 
-    try await GitTagData(backupFile: backupFile).write(
-      tagDatum: patchedTracksData.map { try $0.nextVersion() },
-      initialCommit: initialCommit, branch: branch, version: version)
+    try await backupFile.write(
+      tagDatum: patchedTracksData.map { try $0.nextVersion() }, initialCommit: initialCommit,
+      branch: branch, version: version)
   }
 }

--- a/Sources/iTunes/URL+Write+TagData.swift
+++ b/Sources/iTunes/URL+Write+TagData.swift
@@ -1,0 +1,70 @@
+//
+//  URL+Write+TagData.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 3/17/25.
+//
+
+import Foundation
+import GitLibrary
+import os
+
+extension Logger {
+  fileprivate static let writeTagData = Logger(category: "writeTagData")
+}
+
+extension Git {
+  fileprivate func addAndTag(fileName: String, tag tagName: String, version: String) async throws {
+    try await add(fileName)
+
+    let hasChanges = await {
+      do {
+        try await diff()
+        Logger.writeTagData.info("Empty Tag: \(tagName)")
+        return false
+      } catch {
+        return true
+      }
+    }()
+
+    if hasChanges {
+      try await commit("\(tagName)\n\(version)")
+    }
+    try await tag(tagName)
+  }
+}
+
+extension Tag where Item == Data {
+  fileprivate func add(to git: Git, backupFile: URL, version: String) async throws {
+    Logger.writeTagData.info("Add: \(tag)")
+
+    // this makes memory shoot up, unexpectedly.
+    try item.write(to: backupFile)
+
+    try await git.addAndTag(fileName: backupFile.lastPathComponent, tag: tag, version: version)
+  }
+}
+
+extension URL {
+  func write(tagDatum: [Tag<Data>], initialCommit: String, branch: String, version: String)
+    async throws
+  {
+    let git = Git(directory: self.parentDirectory, suppressStandardErr: true)
+
+    try await git.status()
+
+    try await git.createBranch(named: branch, initialCommit: initialCommit)
+
+    var tagDatum = tagDatum.sorted(by: { $0.tag > $1.tag })  // latest to oldest.
+
+    for tagData in tagDatum.reversed() {
+      tagDatum.removeLast()
+
+      try await tagData.add(to: git, backupFile: self, version: version)
+    }
+
+    //    try await git.push()
+    //    try await git.pushTags()
+    //    try await git.gc()
+  }
+}


### PR DESCRIPTION
it's just an extension on a `URL` now.