### PR TITLE
QueryCommand uses extensions on URL to get databases and run queries.

### DIFF
--- a/Sources/iTunes/Query/QueryCommand.swift
+++ b/Sources/iTunes/Query/QueryCommand.swift
@@ -29,20 +29,18 @@ extension TransformContext {
   fileprivate func query(_ query: String, backupFile: URL) async throws {
     switch self {
     case .tracks(let context):
-      try await GitTagData(backupFile: backupFile).uniqueTracks(
-        query: query, format: DatabaseFormat.normalized(context)
-      )
-      .forEach {
-        print($0.tag)
-        print(try $0.item.jsonData().asUTF8String())
-      }
+      try await backupFile.uniqueTracks(query: query, format: DatabaseFormat.normalized(context))
+        .forEach {
+          print($0.tag)
+          print(try $0.item.jsonData().asUTF8String())
+        }
     case .raw(let format):
-      try await GitTagData(backupFile: backupFile).printOutput(query: query, format: format)
+      try await backupFile.printOutput(query: query, format: format)
     }
   }
 }
 
-extension GitTagData {
+extension URL {
   fileprivate func rowOutput(query: String, format: DatabaseFormat) async throws -> [Tag<[String]>]
   {
     try await transformRows(query: query, format: format) { queryRows in

--- a/Sources/iTunes/URL+Databases.swift
+++ b/Sources/iTunes/URL+Databases.swift
@@ -1,5 +1,5 @@
 //
-//  GitTagData+Databases.swift
+//  URL+Databases.swift
 //  itunes_json
 //
 //  Created by Greg Bolsinga on 1/24/25.
@@ -54,9 +54,9 @@ extension DatabaseFormat {
   }
 }
 
-extension GitTagData {
+extension URL {
   fileprivate func databases(_ format: DatabaseFormat) async throws -> [Tag<Database>] {
-    try await transformTracks {
+    try await GitTagData(backupFile: self).transformTracks {
       try await format.append(tag: $0).database(tracks: $1)
     }
   }

--- a/Sources/iTunes/URL+TracksQuery.swift
+++ b/Sources/iTunes/URL+TracksQuery.swift
@@ -1,13 +1,15 @@
 //
-//  GitTagData+TracksQuery.swift
+//  URL+TracksQuery.swift
 //  itunes_json
 //
 //  Created by Greg Bolsinga on 1/25/25.
 //
 
+import Foundation
+
 typealias TaggedTracks = Tag<[Track]>
 
-extension GitTagData {
+extension URL {
   fileprivate func tracks(query: String, format: DatabaseFormat) async throws
     -> [TaggedTracks]
   {


### PR DESCRIPTION
No longer needs `GitTagData`.