### PR TITLE
Albums table must reference artist

### DIFF
--- a/Sources/iTunes/RowAlbum+SQLBindableInsert.swift
+++ b/Sources/iTunes/RowAlbum+SQLBindableInsert.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 extension RowAlbum: SQLBindableInsert {
-  static var insertBinding: Database.Statement { RowAlbum().insert }
+  static var insertBinding: Database.Statement { RowAlbum().insert(artistID: .empty) }
 }

--- a/Sources/iTunes/Track+RowAlbum.swift
+++ b/Sources/iTunes/Track+RowAlbum.swift
@@ -44,4 +44,8 @@ extension Track: RowAlbumInterface {
     }
     return 0
   }
+
+  var albumArtistName: SortableName? {
+    artistName
+  }
 }

--- a/Sources/iTunes/TrackRowEncoder.swift
+++ b/Sources/iTunes/TrackRowEncoder.swift
@@ -52,8 +52,8 @@ struct TrackRowEncoder {
     return ArtistTableBuilder(rows: artistRows)
   }
 
-  var albumTableBuilder: AlbumTableBuilder {
-    AlbumTableBuilder(rows: Array(Set(rows.map { $0.album })))
+  func albumTableBuilder(artistLookup: [RowArtist: Int64]? = nil) -> AlbumTableBuilder {
+    AlbumTableBuilder(tracks: rows, artistLookup: artistLookup)
   }
 
   func songTableBuilder(

--- a/Sources/iTunes/TracksDBEncoder.swift
+++ b/Sources/iTunes/TracksDBEncoder.swift
@@ -28,8 +28,12 @@ struct TracksDBEncoder<Context: TracksDBEncoderContext> {
     try await db.createTable(rowEncoder.artistTableBuilder, schemaConstraints: schemaConstrainsts)
   }
 
-  private func emitAlbums(schemaConstrainsts: SchemaConstraints) async throws -> [RowAlbum: Int64] {
-    try await db.createTable(rowEncoder.albumTableBuilder, schemaConstraints: schemaConstrainsts)
+  private func emitAlbums(artistLookup: [RowArtist: Int64], schemaConstrainsts: SchemaConstraints)
+    async throws -> [RowAlbum: Int64]
+  {
+    try await db.createTable(
+      rowEncoder.albumTableBuilder(artistLookup: artistLookup),
+      schemaConstraints: schemaConstrainsts)
   }
 
   private func emitSongs(
@@ -53,7 +57,8 @@ struct TracksDBEncoder<Context: TracksDBEncoderContext> {
     try await db.execute("PRAGMA foreign_keys = ON;")
     let schemaOptions = context.schemaOptions
     let artistLookup = try await emitArtists(schemaConstrainsts: schemaOptions.artistConstraints)
-    let albumLookup = try await emitAlbums(schemaConstrainsts: schemaOptions.albumConstraints)
+    let albumLookup = try await emitAlbums(
+      artistLookup: artistLookup, schemaConstrainsts: schemaOptions.albumConstraints)
     let songLookup = try await emitSongs(
       artistLookup: artistLookup, albumLookup: albumLookup,
       schemaConstrainsts: schemaOptions.songConstraints)

--- a/Sources/iTunes/TracksSQLSourceEncoder.swift
+++ b/Sources/iTunes/TracksSQLSourceEncoder.swift
@@ -31,7 +31,7 @@ struct TracksSQLSourceEncoder<Context: TracksSQLSourceEncoderContext> {
     )] {
       [
         (rowEncoder.artistTableBuilder, schemaOptions.artistConstraints),
-        (rowEncoder.albumTableBuilder, schemaOptions.albumConstraints),
+        (rowEncoder.albumTableBuilder(), schemaOptions.albumConstraints),
         (rowEncoder.songTableBuilder(), schemaOptions.songConstraints),
         (rowEncoder.playTableBuilder(), schemaOptions.playsConstraints),
       ]


### PR DESCRIPTION
- There are albums with the same name, trackcount, disccount, discnumber, and compilation that are by different artists. "Greatest Hits" is common.
- Therefore, store the artistID in the albums table.