### PR TITLE
Revert "make itunesid the flat database primary key (#824)"

### DIFF
--- a/Sources/iTunes/FlatTracksDatabaseContext.swift
+++ b/Sources/iTunes/FlatTracksDatabaseContext.swift
@@ -32,7 +32,8 @@ struct FlatTracksDatabaseContext: FlatDBEncoderContext {
 
   let schema: String = """
     CREATE TABLE tracks (
-      itunesid TEXT NOT NULL PRIMARY KEY,
+      id INTEGER PRIMARY KEY,
+      itunesid TEXT NOT NULL,
       name TEXT NOT NULL,
       sortname TEXT NOT NULL DEFAULT '',
       artist TEXT NOT NULL,


### PR DESCRIPTION
This reverts commit cb5be060eb28ad657fc05ace3a78915c06d00ed3.

Turns out there are some backup snapshots that have the same itunesid twice. The first I've found was:

sql: INSERT INTO tracks (itunesid, name, sortname, artist, sortartist, album, sortalbum, tracknumber, trackcount, disccount, discnumber, year, duration, dateadded, compilation, composer, datereleased, comments, playdate, playcount) VALUES ('7576188453071066502', 'Hey Ya!', '', 'OutKast', '', 'Speakerboxxx / The Love Below', '', 9, 21, 2, 2, 2003, 235213, '2004-01-05T20:46:30Z', 0, 'Andr Subsystem: batch-iTunes-V40-2011-08-01: sql | Category: step

This is one of the weird files in iTunes that somehow got two copies. So there are different playcounts for the same itunesid. This will have to be adjusted in the plays table in the future.

Keep the PRIMARY KEY separate from the itunesid for the time being in the flat db.