### PR TITLE
Add ArchiveCommand.

### DIFF
--- a/Sources/iTunes/Archive/ArchiveCommand.swift
+++ b/Sources/iTunes/Archive/ArchiveCommand.swift
@@ -1,0 +1,113 @@
+//
+//  ArchiveCommand.swift
+//  itunes_json
+//
+//  Created by Greg Bolsinga on 4/6/25.
+//
+
+import ArgumentParser
+import Foundation
+import os
+
+extension Logger {
+  fileprivate static let archive = Logger(category: "archive")
+}
+
+private let updateArtists: String =
+  """
+  -- Create a table of itunesid to artist names
+  CREATE TEMPORARY TABLE new_names (itunesid TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, sortname TEXT NOT NULL DEFAULT '');
+  -- Insert all the new artist names and itunesids
+  INSERT INTO new_names (itunesid, name, sortname) SELECT itunesid, artist, sortartist FROM tracks EXCEPT SELECT artist_ids.itunesid, ara.name, ara.sortname FROM archive.artists ara LEFT JOIN archive.artistids artist_ids ON ara.id = artist_ids.artistid;
+  -- Fix new names to be name, sortname if some are set and some are not.
+  UPDATE new_names AS a SET sortname = n.sortname FROM (WITH names AS (SELECT DISTINCT name, sortname FROM new_names) SELECT DISTINCT a.name AS name, COALESCE(NULLIF(a.sortname, ''), NULLIF(o.sortname, ''), '') AS sortname FROM names a LEFT JOIN names o ON a.name=o.name AND a.sortname!=o.sortname ORDER BY name) AS n WHERE a.name = n.name AND a.sortname != n.sortname;
+  -- Update any changed artist names.
+  UPDATE archive.artists AS a SET name = new.name, sortname = new.sortname FROM (SELECT DISTINCT ar.id, new.name, new.sortname FROM archive.artistids artist_ids INNER JOIN new_names new ON new.itunesid = artist_ids.itunesid INNER JOIN archive.artists ar ON ar.id = artist_ids.artistid) AS new WHERE a.id = new.id;
+  -- Insert all the new artist names (even if an existing artist has a new itunesid)
+  INSERT INTO archive.artists (name, sortname) SELECT DISTINCT name, sortname FROM new_names EXCEPT SELECT name, sortname FROM archive.artists;
+  -- Insert all the new itunesid and artistids that aren't already present, in case of an artist name update.
+  INSERT INTO archive.artistids (itunesid, artistid) SELECT DISTINCT new.itunesid, a.id FROM new_names new LEFT JOIN archive.artists a ON new.name = a.name AND new.sortname = a.sortname EXCEPT SELECT artist_ids.itunesid, artist_ids.artistid FROM archive.artistids artist_ids;
+  DROP TABLE new_names;
+  """
+
+extension Database {
+  func archive(into archivePath: String) async throws {
+    try self.transaction { db in
+      try db.execute("ATTACH DATABASE '\(archivePath)' AS archive;")
+
+      try db.execute(updateArtists)
+    }
+  }
+}
+
+struct ArchiveCommand: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "archive",
+    abstract: "Create a normalized archive database from a git repository.",
+    version: iTunesVersion
+  )
+
+  @Flag(help: "Pass true if the archive database should be emptied before running.")
+  var clear: Bool = false
+
+  /// Lax normalized database schema table constraints.
+  @Flag(help: "Lax normalized database schema table constraints")
+  var laxSchema: [SchemaFlag] = []
+
+  /// Git Directory to read and write data from.
+  @Option(
+    help: "The path for the git directory to work with.",
+    transform: ({
+      let url = URL(filePath: $0, directoryHint: .isDirectory)
+      let manager = FileManager.default
+      if !manager.fileExists(atPath: url.relativePath) {
+        try manager.createDirectory(at: url, withIntermediateDirectories: true)
+      }
+
+      return url
+    })
+  )
+  var gitDirectory: URL
+
+  /// Output Directory for batch results.
+  @Option(
+    help: "The path at which to create the archive database.",
+    transform: ({
+      let url = URL(filePath: $0, directoryHint: .isDirectory)
+      let manager = FileManager.default
+      if !manager.fileExists(atPath: url.relativePath) {
+        try manager.createDirectory(at: url, withIntermediateDirectories: true)
+      }
+
+      return url
+    })
+  )
+  var outputDirectory: URL
+
+  /// Optional file name to use.
+  @Option(help: "File name to use when outputDirectory is used.")
+  var fileName: String = "itunes"
+
+  /// Outputfile where data will be writen, if outputDirectory is not specified.
+  private var outputFile: URL {
+    return outputDirectory.appending(path: fileName).appendingPathExtension("db")
+  }
+
+  func run() async throws {
+    if clear { _ = try? FileManager.default.removeItem(at: outputFile) }
+
+    let format = DatabaseFormat.normalized(
+      DatabaseContext(storage: .file(outputFile), schemaOptions: laxSchema.schemaOptions))
+    let archiveDB = try await format.database(tracks: [])
+
+    let databases = gitDirectory.backupFile.databases(
+      .flat(FlatTracksDatabaseContext(storage: .memory)))
+
+    async let archiveDBPath = archiveDB.filename
+
+    for try await database in databases {
+      Logger.archive.info("\(database.tag)")
+      try await database.item.archive(into: await archiveDBPath)
+    }
+  }
+}

--- a/Sources/iTunes/ArtistTableBuilder.swift
+++ b/Sources/iTunes/ArtistTableBuilder.swift
@@ -26,6 +26,10 @@ struct ArtistTableBuilder: TableBuilder {
       id INTEGER PRIMARY KEY,
       \(constraints == .strict ? strictSchema : laxSchema)
     );
+    CREATE TABLE IF NOT EXISTS artistids (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      artistid INTEGER NOT NULL
+    );
     """
   }
 

--- a/Sources/iTunes/Database.swift
+++ b/Sources/iTunes/Database.swift
@@ -416,6 +416,10 @@ actor Database {
     handle.sqlError
   }
 
+  var filename: String {
+    String(cString: sqlite3_db_filename(handle, nil), encoding: .utf8) ?? ""
+  }
+
   func data() throws -> Data {
     var size: sqlite3_int64 = 0
     guard let bytes = sqlite3_serialize(handle, "main", &size, 0) else {

--- a/Sources/iTunes/Program.swift
+++ b/Sources/iTunes/Program.swift
@@ -8,7 +8,7 @@ public struct Program: AsyncParsableCommand {
     version: iTunesVersion,
     subcommands: [
       BackupCommand.self, PatchCommand.self, RepairCommand.self, BatchCommand.self,
-      QueryCommand.self,
+      QueryCommand.self, ArchiveCommand.self,
     ],
     defaultSubcommand: BackupCommand.self
   )

--- a/Sources/iTunes/URL+Databases.swift
+++ b/Sources/iTunes/URL+Databases.swift
@@ -55,9 +55,7 @@ extension DatabaseFormat {
 }
 
 extension URL {
-  fileprivate func databases(_ format: DatabaseFormat) -> AsyncThrowingStream<
-    Tag<Database>, any Error
-  > {
+  func databases(_ format: DatabaseFormat) -> AsyncThrowingStream<Tag<Database>, any Error> {
     transformTracks {
       try await format.append(tag: $0).database(tracks: $1)
     }


### PR DESCRIPTION
- This will read flat databases from a git repository. It will iterate through each and add it to a normalized archive database.
- Right now it only does artists. It can find what artists are new as well as track changes to their name. The "later" versions of the name will replace the older ones. This is just like the artist name repair.
- Adds artistids table, which is a lookup of itunesid -> artistid. This will be used to create the albums and songs tables in future diffs. It is possible this could be a TEMPORARY table; keeping it around for now.