### PR TITLE
Archive albums

### DIFF
--- a/Sources/iTunes/AlbumTableBuilder.swift
+++ b/Sources/iTunes/AlbumTableBuilder.swift
@@ -32,6 +32,10 @@ struct AlbumTableBuilder: TableBuilder {
       CHECK(discnumber > 0),
       CHECK(compilation = 0 OR compilation = 1)
     );
+    CREATE TABLE IF NOT EXISTS albumids (
+      itunesid TEXT NOT NULL PRIMARY KEY,
+      albumid INTEGER NOT NULL
+    );
     """
   }
 


### PR DESCRIPTION
This gets all the albums. Some albums go in wrong, and later once a single track is fixed, it now matches the rest of the tracks in the album. This is a special case where itunesid->albumid is all that changes. Clear out the old album rows.

This schema is a little odd at the moment. There are multiple entries in albums that are all the same, but the artist had to be in there. Learning more, I'll change the the schema so the album tables doesn't mind if there is "duplicate" data. Then there will be a many-to-many table that has all the artists on an album.