### PR TITLE
Remove duplicate play dates from same album using the tracks data

### DIFF
--- a/Sources/iTunes/Archive/ArchiveCommand.swift
+++ b/Sources/iTunes/Archive/ArchiveCommand.swift
@@ -87,15 +87,15 @@ private let updatePlays =
   """
   CREATE TEMPORARY TABLE non_empty_tracks (itunesid TEXT NOT NULL, date TEXT NOT NULL, count INTEGER NOT NULL);
   INSERT INTO non_empty_tracks (itunesid, date, count) SELECT itunesid, playdate, playcount FROM tracks WHERE playdate != '';
+
+  -- Handle duplicate dates from the same album in the source data. Find the earlier tracknumber's duration and add it to the timestamp of the previous date.
+  CREATE TEMPORARY TABLE no_duplicate_date_tracks (itunesid TEXT NOT NULL, date TEXT NOT NULL, count INTEGER NOT NULL);
+  WITH no_duplicate_date_albums AS (WITH fix_duplicate_date_albums AS (WITH duplicate_date_albums AS (WITH duplicate_dates AS (SELECT * FROM non_empty_tracks WHERE date IN (SELECT date FROM non_empty_tracks GROUP BY date HAVING COUNT(*) > 1)) SELECT dd.itunesid, dd.date, dd.count, s.albumid FROM duplicate_dates dd INNER JOIN archive.songs s ON s.itunesid = dd.itunesid) SELECT * FROM duplicate_date_albums dda WHERE albumid IN (SELECT albumid FROM duplicate_date_albums GROUP BY albumid HAVING COUNT(*) > 1)) SELECT a.itunesid, a.date AS date, a.count, CASE WHEN sa.tracknumber + 1 = sb.tracknumber THEN a.date ELSE strftime('%Y-%m-%dT%H:%M:%SZ', datetime(strftime('%s', b.date) + ROUND(sa.duration / 1000), 'unixepoch')) END fixdate FROM fix_duplicate_date_albums a INNER JOIN fix_duplicate_date_albums b ON a.date = b.date AND a.albumid = b.albumid INNER JOIN archive.songs sa ON sa.itunesid = a.itunesid INNER JOIN archive.songs sb ON sb.itunesid = b.itunesid AND sa.tracknumber != sb.tracknumber) INSERT INTO no_duplicate_date_tracks (itunesid, date, count) SELECT itunesid, fixdate AS date, count FROM no_duplicate_date_albums WHERE date != fixdate;
+  UPDATE non_empty_tracks AS a SET date = new.date FROM (SELECT * FROM no_duplicate_date_tracks) AS new WHERE a.itunesid = new.itunesid;
+
   CREATE TEMPORARY TABLE changed_no_quirk_tracks (itunesid TEXT NOT NULL, date TEXT NOT NULL, count INTEGER NOT NULL);
   INSERT INTO changed_no_quirk_tracks (itunesid, date, count) SELECT a.itunesid, CASE WHEN MOD(ABS(strftime('%s', a.date) - strftime('%s', b.date)), 60 * 60) = 0 THEN b.date ELSE a.date END date, a.count FROM non_empty_tracks a LEFT JOIN archive.lastplays b ON a.itunesid=b.itunesid;
   DROP TABLE non_empty_tracks;
-
-  -- Handle when two tracks from the same album have the same date. Find the earlier tracknumber's duration and add it to the timestamp of the previous date.
-  CREATE TEMPORARY TABLE changed_no_quirk_no_duplicate_album_date_tracks (itunesid TEXT NOT NULL, date TEXT NOT NULL, count INTEGER NOT NULL);
-  WITH no_duplicate_date_albums AS (WITH fix_duplicate_date_albums AS (WITH duplicate_date_albums AS (WITH duplicate_dates AS (SELECT * FROM changed_no_quirk_tracks WHERE date IN (SELECT date FROM changed_no_quirk_tracks GROUP BY date HAVING COUNT(*) > 1)) SELECT dd.itunesid, dd.date, dd.count, s.albumid FROM duplicate_dates dd INNER JOIN archive.songs s ON s.itunesid = dd.itunesid) SELECT * FROM duplicate_date_albums dda WHERE albumid IN (SELECT albumid FROM duplicate_date_albums GROUP BY albumid HAVING COUNT(*) > 1)) SELECT a.itunesid, a.date AS date, a.count, CASE WHEN sa.tracknumber + 1 = sb.tracknumber THEN a.date ELSE strftime('%Y-%m-%dT%H:%M:%SZ', datetime(strftime('%s', b.date) + ROUND(sa.duration / 1000), 'unixepoch')) END fixdate FROM fix_duplicate_date_albums a INNER JOIN fix_duplicate_date_albums b ON a.date = b.date AND a.albumid = b.albumid INNER JOIN archive.songs sa ON sa.itunesid = a.itunesid INNER JOIN archive.songs sb ON sb.itunesid = b.itunesid AND sa.tracknumber != sb.tracknumber) INSERT INTO changed_no_quirk_no_duplicate_album_date_tracks (itunesid, date, count) SELECT itunesid, fixdate AS date, count FROM no_duplicate_date_albums WHERE date != fixdate;
-  UPDATE changed_no_quirk_tracks AS a SET date = new.date FROM (SELECT * FROM changed_no_quirk_no_duplicate_album_date_tracks) AS new WHERE a.itunesid = new.itunesid;
-  DROP TABLE changed_no_quirk_no_duplicate_album_date_tracks;
 
   INSERT INTO archive.plays (itunesid, date, count) SELECT * FROM changed_no_quirk_tracks EXCEPT SELECT arp.itunesid, arp.date, arp.count FROM archive.lastplays AS arp;
   DROP TABLE changed_no_quirk_tracks;


### PR DESCRIPTION
- This way all the changes are consistent. archive.plays will have the already corrected data. Therefore the non-de-duplicated date will show up as something new.
- This is the same, just moved up earlier to use non_empty_tracks instead of changed_no_quirk_tracks.