### PR TITLE
Enforce the order of the archving

### DIFF
--- a/Sources/iTunes/Archive/ArchiveCommand.swift
+++ b/Sources/iTunes/Archive/ArchiveCommand.swift
@@ -191,7 +191,11 @@ struct ArchiveCommand: AsyncParsableCommand {
 
     async let archiveDBPath = archiveDB.filename
 
-    for try await database in databases {
+    for database in try await databases.reduce(into: [Tag<Database>](), { $0.append($1) }).sorted(
+      by: {
+        $0.tag < $1.tag
+      })
+    {
       Logger.archive.info("\(database.tag)")
       try await database.item.archive(into: await archiveDBPath)
     }


### PR DESCRIPTION
It had seemed that the `AsyncStream`s would return the `Database`s in `Tag` order, but that has not proven to be the case. This would mess up the archiving logic for plays. Therefore, build all the `Database`s in memory before archiving them.