### PR TITLE
Use Array instead of Collection to remove concurrency warning

### DIFF
--- a/Sources/iTunes/Array+Changes.swift
+++ b/Sources/iTunes/Array+Changes.swift
@@ -1,11 +1,11 @@
 //
-//  Collection+Changes.swift
+//  Array+Changes.swift
 //  itunes_json
 //
 //  Created by Greg Bolsinga on 11/30/24.
 //
 
-extension Collection where Element: Sendable {
+extension Array where Element: Sendable {
   func changes<T: Sendable>(createChange: @escaping @Sendable (Element) -> [T]) async -> [T] {
     await withTaskGroup(of: Array<T>.self) { group in
       self.forEach { element in


### PR DESCRIPTION
Fixes: `Capture of non-sendable type 'Self.Type' in an isolated closure`