### PR TITLE
use a specific version of PackageBuildInfo instead of a branch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     .package(url: "https://github.com/bolsinga/GitLibrary", from: "1.1.2"),
-    .package(url: "https://github.com/bolsinga/PackageBuildInfo", branch: "main"),
+    .package(url: "https://github.com/bolsinga/PackageBuildInfo", exact: "2.0.0"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
   ],
   targets: [


### PR DESCRIPTION
helps with builds that depend upon this package.