### PR TITLE
Track.dateModified should be a String

### DIFF
--- a/Sources/iTunes/Track+MediaItem.swift
+++ b/Sources/iTunes/Track+MediaItem.swift
@@ -40,7 +40,7 @@ import Foundation
         self.contentRating = contentRating
       }
       self.dateAdded = mediaItem.addedDate?.formatted(.iso8601)
-      self.dateModified = mediaItem.modifiedDate
+      self.dateModified = mediaItem.modifiedDate?.formatted(.iso8601)
       if mediaItem.isUserDisabled {
         self.disabled = mediaItem.isUserDisabled
       }

--- a/Sources/iTunes/Track.swift
+++ b/Sources/iTunes/Track.swift
@@ -21,7 +21,7 @@ struct Track: Codable, Hashable, Sendable {
   var composer: String? = nil  // "Composer"
   var contentRating: String? = nil  // "Content Rating"
   var dateAdded: String? = nil  // "Date Added"
-  var dateModified: Date? = nil  // "Date Modified"
+  var dateModified: String? = nil  // "Date Modified"
   var disabled: Bool? = nil  // "Disabled"
   var discCount: Int? = nil  // "Disc Count"
   var discNumber: Int? = nil  // "Disc Number"


### PR DESCRIPTION
- Fixes a bug introduced with #851
- The dateModified field in the json output would be garbage (since it is no longer automaticallly encoding).