### PR TITLE
Update Package.swift to target OS 26.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Available Xcodes
       run: ls /Applications | grep Xcode
     - name: Switch to Xcode 26
-      run: sudo xcode-select -s "/Applications/Xcode_26.2.app/Contents/Developer"
+      run: sudo xcode-select -s "/Applications/Xcode_26.4.app/Contents/Developer"
     - name: Xcode Version
       run: xcodebuild -version
     - name: Install iOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Available Xcodes
       run: ls /Applications | grep Xcode
     - name: Switch to Xcode 26
-      run: sudo xcode-select -s "/Applications/Xcode_26.2.app/Contents/Developer"
+      run: sudo xcode-select -s "/Applications/Xcode_26.4.app/Contents/Developer"
     - name: Xcode Version
       run: xcodebuild -version
     - name: Install iOS

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.3
 
 import PackageDescription
 
@@ -6,18 +6,18 @@ let package = Package(
   name: "itunes_json",
   defaultLocalization: "en",
   platforms: [
-    .macOS(.v15),
-    .iOS(.v18),
+    .macOS(.v26),
+    .iOS(.v26),
   ],
   products: [
     .library(name: "iTunes", targets: ["iTunes"]),
     .executable(name: "tunes", targets: ["tunes"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.6.1"),
-    .package(url: "https://github.com/bolsinga/GitLibrary", from: "1.1.2"),
-    .package(url: "https://github.com/bolsinga/PackageBuildInfo", exact: "2.0.0"),
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.2.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.8.2"),
+    .package(url: "https://github.com/bolsinga/GitLibrary", exact: "1.1.2"),
+    .package(url: "https://github.com/bolsinga/PackageBuildInfo", exact: "2.0.1"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.6.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
also update spm dependencies, GitLibrary needs a fixed version, since I didn't version it properly with a breaking API change.